### PR TITLE
fix(session): check for valid session before API calls

### DIFF
--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -205,11 +205,11 @@ export const AppProvider = (props) => {
   function checkSession() {
     const localToken = JSON.parse(localStorage.getItem('token'));
     const localUser = JSON.parse(localStorage.getItem('user'));
-    if (localToken && localUser) {
+
+    if (localToken && localUser && session.token) {
       // Temporarily log in with the localStorage credentials while
       // we check that the session is still valid
       login(localUser, localToken);
-
       axios
         .get(
           `${process.env.REACT_APP_API_ROOT}/auth/check_session?id=${localUser.id}`,
@@ -232,6 +232,7 @@ export const AppProvider = (props) => {
             logout();
           }
         });
+
       return true;
     }
     return false;


### PR DESCRIPTION
## Description

Add condition session.token to execute checkSession only if session.token and other conditions are true. Otherwise 5 more API calls from getTotalUnprocessed, getTotalVerified, loadOrganizations, getTotal, and getTotalGrowerCount will fetch data. 

**Issue(s) addressed**
- Resolves #290 

**What kind of change(s) does this PR introduce?**

- [ ] Enhancement
- [x] Bug fix
- [ ] Refactor

**Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The app does not logout properly upon 401 error. checkSession is not checking for valid session so logging in will trigger all API calls from mounting DashStat Components.  

**What is the new behavior?**
App will logout and stop making API calls when JWT token changes. 

## Breaking change

**Does this PR introduce a breaking change?**
No

## Other useful information
Currently no catch method on checkSession to logout on error. Does not handle 401 error specifically 
