### PR TITLE
feat: Export options updated

### DIFF
--- a/src/components/Captures/CaptureTable.js
+++ b/src/components/Captures/CaptureTable.js
@@ -106,6 +106,19 @@ const columns = [
   },
 ];
 
+//additional columns for export options, passed to ExportCaptures
+const exportColumns = [
+  ...columns,
+  {
+    attr: 'id',
+    label: 'Capture UUID',
+  },
+  {
+    attr: 'wallet_token_id',
+    label: 'Wallet UUID',
+  },
+];
+
 const CaptureTable = () => {
   const {
     filter,
@@ -227,7 +240,7 @@ const CaptureTable = () => {
           <ExportCaptures
             isOpen={isOpenExport}
             handleClose={() => setOpenExport(false)}
-            columns={columns}
+            columns={exportColumns}
             filter={filter}
             speciesLookup={speciesLookup}
           />
@@ -323,7 +336,7 @@ export const formatCell = (capture, speciesLookup, attr, renderer) => {
       />
     );
   } else if (attr === 'species_id') {
-    return capture[attr] === null ? '--' : speciesLookup[capture[attr]];
+    return capture[attr] === null ? '' : speciesLookup[capture[attr]];
   } else {
     return renderer ? renderer(capture[attr]) : capture[attr];
   }

--- a/src/components/ExportCaptures.js
+++ b/src/components/ExportCaptures.js
@@ -64,7 +64,9 @@ const ExportCaptures = (props) => {
     return captures.map((capture) => {
       let formattedCapture = {};
       Object.keys(selectedColumns).forEach((attr) => {
-        if (['id', 'grower_account_id', 'imageUrl'].includes(attr)) {
+        if (
+          ['reference_id', 'grower_reference_id', 'image_url'].includes(attr)
+        ) {
           formattedCapture[attr] = capture[attr];
         } else {
           const renderer = selectedColumns[attr].renderer;


### PR DESCRIPTION
## Description
Capture UUID and Wallet UUID options added to Export Captures module.
Incorrectly displayed fields in the downloaded csv (reference_id, grower_reference_id, image_url) fixed.

**Issue(s) addressed**
- Resolves #928 

**What kind of change(s) does this PR introduce?**
- [X] Enhancement
- [X] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
- Export Captures modules doesn't contain Capture UUID and Wallet UUID options.
- The downloaded csv displays the `reference_id, grower_reference_id, image_url` fields incorrectly as shown below:
![wallet_issue_928](https://github.com/Greenstand/treetracker-admin-client/assets/15161954/0a3e01b7-6add-4f76-b862-0604d8cf1656)


**What is the new behavior?**
- Export Captures module has new options added as shown below:
![export_fix_928](https://github.com/Greenstand/treetracker-admin-client/assets/15161954/867e7acc-2a15-48af-8038-e2bed4613efa)
- The downloaded csv displays the fields correctly as shown below:
![wallet_fix_928](https://github.com/Greenstand/treetracker-admin-client/assets/15161954/14875e66-f109-48ce-a19d-91dd6ba6ef97)

## Breaking change

**Does this PR introduce a breaking change?**
No

## Other useful information
None
