### PR TITLE
Show in Web Map toggle

### DIFF
--- a/src/components/GrowerDetail.js
+++ b/src/components/GrowerDetail.js
@@ -16,6 +16,7 @@ import {
   ListItem,
   ListItemAvatar,
   ListItemText,
+  Switch,
   Typography,
 } from '@material-ui/core';
 import {
@@ -148,7 +149,7 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
   // log.debug('render: grower detail', growerId);
   const classes = useStyle();
   const appContext = useContext(AppContext);
-  const { growers } = useContext(GrowerContext);
+  const { growers, updateGrower } = useContext(GrowerContext);
   const { sendMessageFromGrower } = useContext(MessagingContext);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [grower, setGrower] = useState({});
@@ -159,6 +160,9 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
   const [loading, setLoading] = useState(false);
   const [isImageLoading, setIsImageLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState(null);
+
+  // show in webmap
+  const [showInWebmap, setShowInWebmap] = useState(false);
 
   function formatDevices(grower) {
     // deduplicate and format
@@ -182,6 +186,7 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
 
   useEffect(() => {
     setErrorMessage(null);
+
     async function loadGrowerDetail() {
       if (grower && grower.grower_account_id !== growerId) {
         setGrower({});
@@ -194,6 +199,7 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
         }
 
         setGrower(match);
+        setShowInWebmap(match.show_in_map);
 
         if (match?.devices?.length) {
           const devices = formatDevices(match);
@@ -201,6 +207,7 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
         }
       }
     }
+
     loadGrowerDetail();
     // eslint-disable-next-line
   }, [growerId, growers]);
@@ -227,6 +234,7 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
         setLoading(false);
       }
     }
+
     loadCaptures();
   }, [grower]);
 
@@ -270,6 +278,23 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
     setSnackbarLabel(label);
     setSnackbarOpen(true);
   }
+
+  async function handleSwitchChange(e) {
+    const toggle = e.target.checked;
+    setShowInWebmap(toggle);
+
+    try {
+      const updatedGrower = {
+        id: grower.id,
+        show_in_map: toggle,
+      };
+      await updateGrower(updatedGrower);
+    } catch (error) {
+      setErrorMessage('Error updating grower detail');
+      setShowInWebmap(!toggle);
+    }
+  }
+
   return (
     <>
       <Drawer
@@ -406,6 +431,19 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
                     </Button>
                   </Grid>
                 )}
+              <Divider />
+              <Grid
+                container
+                direction="row"
+                className={classes.box}
+                style={{
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                }}
+              >
+                <Typography variant="subtitle1">Show in Web Map</Typography>
+                <Switch checked={showInWebmap} onChange={handleSwitchChange} />
+              </Grid>
               <Divider />
               <Grid container direction="column" className={classes.box}>
                 <Typography variant="subtitle1" className={classes.captures}>

--- a/src/components/OptimizedImage.js
+++ b/src/components/OptimizedImage.js
@@ -67,6 +67,7 @@ export default function OptimizedImage(props) {
           src={cdnUrl || src}
           onError={({ currentTarget }) => {
             currentTarget.onerror = null;
+            currentTarget.srcset = null;
             currentTarget.src = null;
           }}
           alt=".."


### PR DESCRIPTION
## Description
A toggle is added to Grower Detail that allows user to change if the grower is to be shown in the web map.

**Issue(s) addressed**
- Resolves #1038 

**What kind of change(s) does this PR introduce?**
- [X] Enhancement
- [X] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
There is no way to edit if grower should be shown on the web map.

**What is the new behavior?**
- A toggle component is added.
![image](https://github.com/Greenstand/treetracker-admin-client/assets/15161954/d1b20c2f-65e5-458e-8b8a-dc142d75d779)

- Changing the toggle updates the grower account `show_in_map` option.

- Minor fix in `OptimizedImage.js` (Verify Capture view). On failing to load an image, the component doesn't constantly retry the request.


## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
None.
