### PR TITLE
Update npm install command to ignore engines

### DIFF
--- a/.github/workflows/treetracker-frontend-pr.yml
+++ b/.github/workflows/treetracker-frontend-pr.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: ${{ env.node-version }}
       - name: npm clean install
-        run: npm ci --legacy-peer-deps
+        run: npm ci --legacy-peer-deps --ignore-engines
         working-directory: ${{ env.project-directory }}
       - name: run ESLint
         run: npm run lint


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow for the frontend project. The change ensures that the npm install step ignores engine checks, which can help prevent build failures due to strict engine requirements.

* Updated the `npm ci` step in `.github/workflows/treetracker-frontend-pr.yml` to include the `--ignore-engines` flag, allowing the workflow to bypass engine compatibility checks during dependency installation.## Description
<!-- Add a brief description of the changes -->

**Issue(s) addressed**
<!-- List resolved issues here, e.g. Resolves #123 (one issue per line) -->
- Resolves #1144 

**What kind of change(s) does this PR introduce?**
<!-- Tick all that apply by replacing [ ] with [x] -->

- [ ] Enhancement
- [x] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**
<!-- Tick all that apply by replacing [ ] with [x] -->
<!-- You are responsible for adding/updating tests for your changes. -->

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
