### PR TITLE
fix(ci): align build and release workflow with deploy workflow

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -29,45 +29,80 @@ jobs:
           echo "::debug:: begin preparing...";
           echo "::debug:: branch to rlease: $GITHUB_REF_NAME"
           node <<EOF >> $GITHUB_OUTPUT
-            const ref = process.env.GITHUB_REF_NAME
             const s3BucketSecretNames = {
-              "master": "DEV_CDN_S3_BUCKET",
-              "freetown": "DEV_CDN_S3_BUCKET_FREETOWN",
-              "beta": "DEV_STAGING_CDN_S3_BUCKET",
-              "alpha": "DEV_ALPHA_CDN_S3_BUCKET",
+              "master-dev": "DEV_CDN_S3_BUCKET",
+              "master-prod": "PROD_CDN_S3_BUCKET",
+              "freetown-dev": "DEV_CDN_S3_BUCKET_FREETOWN",
+              "freetown-prod": "PROD_CDN_S3_BUCKET_FREETOWN",
+              "beta-dev": "DEV_STAGING_CDN_S3_BUCKET",
+              "beta-prod": "STAGING_CDN_S3_BUCKET",
+              "alpha-dev": "DEV_ALPHA_CDN_S3_BUCKET",
+              "alpha-prod": "PROD_ALPHA_CDN_S3_BUCKET",
             }
+
             const cdnIdSecretNames = {
-              "master": "DEV_CDN_DISTRIBUTION_ID",
-              "freetown": "DEV_CDN_DISTRIBUTION_ID_FREETOWN",
-              "beta": "DEV_STAGING_CDN_DISTRIBUTION_ID",
-              "alpha": "DEV_ALPHA_CDN_DISTRIBUTION_ID",
+              "master-dev": "DEV_CDN_DISTRIBUTION_ID",
+              "master-prod": "PROD_CDN_DISTRIBUTION_ID",
+              "freetown-dev": "DEV_CDN_DISTRIBUTION_ID_FREETOWN",
+              "freetown-prod": "PROD_CDN_DISTRIBUTION_ID_FREETOWN",
+              "beta-dev": "DEV_STAGING_CDN_DISTRIBUTION_ID",
+              "beta-prod": "STAGING_CDN_DISTRIBUTION_ID",
+              "alpha-dev": "DEV_ALPHA_CDN_DISTRIBUTION_ID",
+              "alpha-prod": "PROD_ALPHA_CDN_DISTRIBUTION_ID",
             }
-            const releaseJson = require("./.releaserc.json");        
-            const branches = releaseJson.branches.map(e => e.name? e.name : e);
-            if(branches.indexOf(ref) === -1){
-              console.log("NO_NEED_TO_BUILD=true");
-              process.exit(0);
+
+            const releaseJson = require("./.releaserc.json");
+
+            // Try to get version from env if available
+            const version = process.env.VERSION_TO_DEPLOY || '';
+
+            const ref = process.env.GITHUB_REF_NAME || '';
+
+            // default env to dev when not explicit
+            let env = process.env.ENV_TO_DEPLOY || 'dev';
+
+            let channel = false;
+            if (version) {
+              const m = version.match(/^v\d+\.\d+\.\d+(-([\w-\/\.]+)\.\d+)?$/);
+              if (!m) {
+                throw '::error:: wrong version:' + version;
+              } else {
+                if(!m[1]) {
+                  channel = "master";
+                } else {
+                  const releaseName = m[2];
+                  channel = releaseJson.branches.reduce((a,c) => a || (c.prerelease === releaseName && c.channel) || (c.name === releaseName && c.channel), false);
+                }
+              }
             }
-            let channel = releaseJson.branches.reduce((a,c) => a || (c === ref && c) || (c.name === ref && c.channel), false);
-            let s3BucketSecretName;
-            let cdnIdSecretName;
-            s3BucketSecretName = s3BucketSecretNames[channel];
-            if(!s3BucketSecretName){
-              throw '::error:: can not find s3 bucket secret name by, channel:' + channel ;
+
+            if(!channel) {
+              const branches = releaseJson.branches.map(e => e.name ? e.name : e);
+              if (branches.indexOf(ref) === -1) {
+                console.log("NO_NEED_TO_BUILD=true");
+                process.exit(0);
+              }
+              channel = releaseJson.branches.reduce((a,c) => a || (c === ref && c) || (c.name === ref && c.channel), false);
             }
-            cdnIdSecretName = cdnIdSecretNames[channel];
-            if(!cdnIdSecretName){
-              throw '::error:: can not find cdn id secret name by, channel:' + channel ;
+
+            const key = channel + '-' + env;
+            const s3BucketSecretName = s3BucketSecretNames[key];
+            if(!s3BucketSecretName) {
+              throw '::error:: can not find s3 bucket secret name by, channel:' + channel + ' env:' + env;
             }
+            const cdnIdSecretName = cdnIdSecretNames[key];
+            if(!cdnIdSecretName) {
+              throw '::error:: can not find cdn id secret name by, channel:' + channel + ' env:' + env;
+            }
+
             console.log("CHANNEL=" + channel);
             console.log("S3_BUCKET_SECRET_NAME=" + s3BucketSecretName);
             console.log("CDN_ID_SECRET_NAME=" + cdnIdSecretName);
-            
           EOF
         id: resolver
         env:
-          VERSION_TO_DEPLOY: ${{ github.event.inputs.version }}
-          ENV_TO_DEPLOY: ${{ github.event.inputs.env }}
+          VERSION_TO_DEPLOY: ${{ github.event.inputs.version || '' }}
+          ENV_TO_DEPLOY: ${{ github.event.inputs.env || '' }}
       - run: |
           echo "channel: ${{ steps.resolver.outputs.CHANNEL}}"
           echo "s3: ${{ steps.resolver.outputs.S3_BUCKET_SECRET_NAME}}"


### PR DESCRIPTION
## Description

This PR updates the prepare job in build_and_release.yaml workflow to use the same environment resolution logic as deploy.yml workflow. It ensures that the resources are selected based on both the release channel and target environment (dev, test, prod). This eliminates mismatches where Build & Release previously deployed to the wrong environment.

**Issue(s) addressed**

- Resolves #1165

**What kind of change(s) does this PR introduce?**

- [ ] Enhancement
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The build_and_release.yaml workflow resolves deployment targets using only the release channel (e.g., master, freetown) and ignores the environment (dev, test, prod). This causes deployments to go to incorrect S3 buckets and CDN distributions.

**What is the new behavior?**
The workflow now resolves secrets using a combined channel-env key (e.g., freetown-prod), matching the logic used in deploy.yml. This ensures consistent and correct deployment targets across both workflows.

## Breaking change

**Does this PR introduce a breaking change?**
No, this change is backward-compatible and improves correctness without altering existing interfaces or behavior for consumers.

## Other useful information
