### PR TITLE
feat: adding an edit icon to the existing photo to upload a new image

### DIFF
--- a/src/components/EditGrower.js
+++ b/src/components/EditGrower.js
@@ -70,6 +70,27 @@ const EditGrower = (props) => {
     }
   }
 
+  /**
+   * Issue 192 https://github.com/Greenstand/treetracker-admin-client/issues/192
+   */
+  function handleImageUpload(newImageUrl) {
+    if (!newImageUrl) {
+      return;
+    }
+
+    setGrowerImages((prevImages) => {
+      if (prevImages.includes(newImageUrl)) {
+        return prevImages;
+      }
+      return [...prevImages, newImageUrl];
+    });
+
+    setGrowerUpdate((prev) => ({
+      ...(prev || {}),
+      imageUrl: newImageUrl,
+    }));
+  }
+
   async function handleSave() {
     if (growerUpdate) {
       setSaveInProgress(true);
@@ -139,6 +160,7 @@ const EditGrower = (props) => {
               growerUpdate?.imageRotation || grower.imageRotation || 0
             }
             onSelectChange={handleChange}
+            onUpload={handleImageUpload}
           />
           {inputs.map((row, rowIdx) => (
             <Grid item container direction="row" key={rowIdx}>

--- a/src/components/ImageScroller.js
+++ b/src/components/ImageScroller.js
@@ -1,7 +1,22 @@
 import React, { useState, useRef } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Fab, Grid, CircularProgress, Card, Button } from '@material-ui/core';
-import { ChevronLeft, ChevronRight } from '@material-ui/icons';
+import {
+  Fab,
+  Grid,
+  CircularProgress,
+  Card,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+} from '@material-ui/core';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Edit as EditIcon,
+} from '@material-ui/icons';
 import Rotate90DegreesCcwIcon from '@material-ui/icons/Rotate90DegreesCcw';
 import OptimizedImage from './OptimizedImage';
 
@@ -56,6 +71,18 @@ const useStyle = makeStyles((theme) => ({
   scrollRight: {
     right: `-${SCROLL_BUTTON_SIZE / 2}px`,
   },
+  editOverlay: {
+    display: 'none',
+  },
+  clickEdit: {
+    margin: 5,
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    width: 32,
+    height: 32,
+    zIndex: 5,
+  },
   loadMore: {
     margin: theme.spacing(1.5),
   },
@@ -84,11 +111,16 @@ export default function ImageScroller(props) {
     blankMessage = '',
     imageRotation,
     onSelectChange,
+    onUpload,
   } = props;
   const classes = useStyle();
   const [maxImages, setMaxImages] = useState(MAX_IMAGES_INCREMENT);
   const imageScrollerRef = useRef(null);
   let [rotation, setRotation] = useState(imageRotation);
+
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [pendingUrl, setPendingUrl] = useState('');
+  const [previewUrl, setPreviewUrl] = useState('');
 
   function loadMoreImages() {
     setMaxImages(maxImages + MAX_IMAGES_INCREMENT);
@@ -129,6 +161,99 @@ export default function ImageScroller(props) {
     }
   }
 
+  function openEditDialog() {
+    setEditDialogOpen(true);
+  }
+
+  function closeEditDialog() {
+    setEditDialogOpen(false);
+    setPendingUrl('');
+    setPreviewUrl('');
+  }
+
+  function scaleToSquareImage(file, size = IMAGE_CARD_SIZE) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = function (ev) {
+        const img = new Image();
+        img.onload = function () {
+          const canvas = document.createElement('canvas');
+          canvas.width = size;
+          canvas.height = size;
+          const ctx = canvas.getContext('2d');
+
+          const aspect = img.width / img.height;
+          let sw = img.width;
+          let sh = img.height;
+          let sx = 0;
+          let sy = 0;
+
+          if (aspect > 1) {
+            // landscape
+            sw = img.height;
+            sx = (img.width - img.height) / 2;
+          } else {
+            // portrait
+            sh = img.width;
+            sy = (img.height - img.width) / 2;
+          }
+
+          ctx.drawImage(img, sx, sy, sw, sh, 0, 0, size, size);
+          resolve(canvas.toDataURL('image/jpeg', 0.9));
+        };
+        img.onerror = reject;
+        img.src = ev.target.result;
+      };
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  }
+
+  async function handleFileInput(event) {
+    const file = event?.target?.files?.[0];
+    if (!file) {
+      setPreviewUrl('');
+      return;
+    }
+
+    setPendingUrl('');
+
+    try {
+      const scaledDataUrl = await scaleToSquareImage(file, IMAGE_CARD_SIZE);
+      setPreviewUrl(scaledDataUrl);
+    } catch (_) {
+      const url = URL.createObjectURL(file);
+      setPreviewUrl(url);
+    }
+  }
+
+  function handleUrlInput(event) {
+    setPendingUrl(event.target.value);
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+      setPreviewUrl('');
+    }
+  }
+
+  function handleUpload() {
+    const chosenUrl = pendingUrl?.trim() || previewUrl;
+    if (!chosenUrl) {
+      return;
+    }
+
+    if (onUpload) {
+      onUpload(chosenUrl);
+    }
+
+    onSelectChange('imageUrl', chosenUrl);
+
+    if (previewUrl && !pendingUrl) {
+      // keep preview URL for display until dialog closes
+    }
+
+    closeEditDialog();
+  }
+
   return (
     <div className={classes.container}>
       <Grid
@@ -157,18 +282,26 @@ export default function ImageScroller(props) {
                 rotation={img === selectedImage ? rotation : 0}
                 onClick={() => handleImageChange(img)}
               />
-              {img === selectedImage ? (
-                <Fab
-                  id="click-rotate"
-                  className={classes.clickRotate}
-                  onClick={handleRotationChange}
-                >
-                  <Rotate90DegreesCcwIcon
-                    style={{ transform: `rotateY(180deg)` }}
-                  />
-                </Fab>
-              ) : (
-                ''
+              {img === selectedImage && (
+                <>
+                  <Fab
+                    id="click-rotate"
+                    className={classes.clickRotate}
+                    onClick={handleRotationChange}
+                  >
+                    <Rotate90DegreesCcwIcon
+                      style={{ transform: `rotateY(180deg)` }}
+                    />
+                  </Fab>
+                  <Fab
+                    id="click-edit"
+                    className={classes.clickEdit}
+                    onClick={openEditDialog}
+                    size="small"
+                  >
+                    <EditIcon style={{ transform: 'scale(0.8)' }} />
+                  </Fab>
+                </>
               )}
             </Card>
           ))
@@ -203,6 +336,63 @@ export default function ImageScroller(props) {
           </Fab>
         </>
       )}
+
+      <Dialog
+        open={editDialogOpen}
+        onClose={closeEditDialog}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Edit grower image</DialogTitle>
+        <DialogContent>
+          <Grid container spacing={2} direction="column">
+            <Grid item>
+              <input
+                id="new-image-file"
+                type="file"
+                accept="image/*"
+                onChange={handleFileInput}
+                data-testid="image-file-input"
+              />
+            </Grid>
+            <Grid item>
+              <TextField
+                label="Or paste image URL"
+                value={pendingUrl}
+                onChange={handleUrlInput}
+                fullWidth
+                variant="outlined"
+                data-testid="image-url-input"
+              />
+            </Grid>
+            <Grid item>
+              {(previewUrl || pendingUrl) && (
+                <img
+                  src={pendingUrl || previewUrl}
+                  alt="Preview"
+                  style={{
+                    width: '100%',
+                    maxHeight: 240,
+                    objectFit: 'contain',
+                  }}
+                  data-testid="image-preview"
+                />
+              )}
+            </Grid>
+          </Grid>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeEditDialog}>Cancel</Button>
+          <Button
+            onClick={handleUpload}
+            variant="contained"
+            color="primary"
+            disabled={!pendingUrl && !previewUrl}
+          >
+            Upload & use
+          </Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/OptimizedImage.js
+++ b/src/components/OptimizedImage.js
@@ -25,34 +25,47 @@ export default function OptimizedImage(props) {
   if (!src) return null;
 
   const cdnPath = `${process.env.REACT_APP_IMAGES_API_ROOT}/img`;
-  const matches = src.match(/\/\/(.*?)\/(.*)/);
+  const isDataUrl = src.startsWith('data:');
+  const isAbsoluteUrl = /^(https?:)?\/\//.test(src);
 
-  let cdnUrl, sizes, srcSet;
+  let cdnUrl;
+  let sizes;
+  let srcSet;
 
-  if (matches?.length > 1) {
-    const domain = matches[1];
-    const imagePath = matches[2];
-    const params =
-      (width ? `w=${Math.floor(width)},` : '') +
-      (height ? `h=${Math.floor(height)},` : '') +
-      (quality ? `q=${quality},` : '') +
-      (rotation ? `r=${rotation}` : '');
+  if (!isDataUrl && isAbsoluteUrl) {
+    const matches = src.match(/\/\/(.*?)\/(.*)/);
+    if (matches?.length > 1) {
+      const domain = matches[1];
+      const imagePath = matches[2];
+      const params =
+        (width ? `w=${Math.floor(width)},` : '') +
+        (height ? `h=${Math.floor(height)},` : '') +
+        (quality ? `q=${quality},` : '') +
+        (rotation ? `r=${rotation}` : '');
 
-    cdnUrl = `${cdnPath}/${domain}/${params}/${imagePath}`;
+      cdnUrl = `${cdnPath}/${domain}/${params}/${imagePath}`;
 
-    if (!fixed && screenWidths.length === imageSizes.length) {
-      sizes = screenWidths
-        .map((size, i) => `(width: ${size}px) ${imageSizes[i]}px`)
-        .join(', ');
-      srcSet = imageSizes
-        .map((size) => `${cdnPath}/${domain}/${params}/${imagePath} ${size}w`)
-        .join(', ');
+      if (!fixed && screenWidths.length === imageSizes.length) {
+        sizes = screenWidths
+          .map((size, i) => `(width: ${size}px) ${imageSizes[i]}px`)
+          .join(', ');
+        srcSet = imageSizes
+          .map((size) => `${cdnPath}/${domain}/${params}/${imagePath} ${size}w`)
+          .join(', ');
+      }
     }
   }
 
+  const imageSrc = cdnUrl || src;
+
+  const useCssRotation = !cdnUrl && rotation;
+  const rotationTransform = useCssRotation
+    ? `rotate(${rotation}deg)`
+    : undefined;
+
   return (
     <>
-      {!cdnUrl || !src ? (
+      {!imageSrc ? (
         <ImageErrorAlert
           alertHeight={alertHeight}
           alertWidth={alertWidth}
@@ -63,7 +76,7 @@ export default function OptimizedImage(props) {
         />
       ) : (
         <img
-          src={cdnUrl || src}
+          src={imageSrc}
           onError={({ currentTarget }) => {
             currentTarget.onerror = null;
             currentTarget.src = null;
@@ -81,6 +94,7 @@ export default function OptimizedImage(props) {
             objectFit,
             maxWidth: '100%',
             maxHeight: '100%',
+            transform: rotationTransform,
           }}
           {...rest}
         />


### PR DESCRIPTION
## Description

Adding a new edit icon to the image to upload a new photo via url or from local machine

**Issue(s) addressed**

- Resolves #192 

**What kind of change(s) does this PR introduce?**

- [X] Enhancement
- [ ] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [X] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**

**What is the new behavior?**
- -> I added an edit icon in the bottom left corner of the photo.

<img width="514" height="308" alt="Image" src="https://github.com/user-attachments/assets/a7dda50c-2b17-4cf0-a957-f609c1674910" />

-> 1) if the user wants to upload a photo, the user can either provide an external URL or upload from local machine.
     2) after clicking the edit icon, a dialog is prompted with two options, and click upload button to see the old and new images.
 
<img width="597" height="191" alt="Image" src="https://github.com/user-attachments/assets/9f1817f0-0aa4-4914-a3ac-ce6648faa425" />

<img width="513" height="417" alt="Image" src="https://github.com/user-attachments/assets/bdd5a734-864d-40d5-9295-df0c4162f59e" />

 -> 3) After the user saved the changes, the previous photo will be replaced by the new image.

<img width="1334" height="896" alt="Image" src="https://github.com/user-attachments/assets/7ec4c1de-e9e4-4a39-b582-3aae0d6aaf76" />

## Breaking change

**Does this PR introduce a breaking change?** 
No

## Other useful information
