### PR TITLE
feat: Add show_in_map toggle

### DIFF
--- a/src/api/growers.js
+++ b/src/api/growers.js
@@ -39,6 +39,7 @@ export default {
           organizationId: true,
           imageRotation: true,
           id: true,
+          show_in_map: true,
           // growerAccountUuid: true,
         },
       };

--- a/src/components/GrowerDetail.js
+++ b/src/components/GrowerDetail.js
@@ -411,10 +411,7 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
                   </Grid>
                 )}
               <Divider />
-              <ShowInMapToggle
-                grower={grower}
-                setErrorMessage={setErrorMessage}
-              />
+              <ShowInMapToggle grower={grower} />
               <Divider />
               <Grid container direction="column" className={classes.box}>
                 <Typography variant="subtitle1" className={classes.captures}>
@@ -585,19 +582,21 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
 
 export default GrowerDetail;
 
-const ShowInMapToggle = ({ grower, setErrorMessage }) => {
+const ShowInMapToggle = ({ grower }) => {
   const classes = useStyle();
   const { updateGrower } = useContext(GrowerContext);
+  const [showInMap, setShowInMap] = useState(!!grower?.show_in_map);
 
-  const handleSwitchChange = async (e) => {
-    const toggle = e.target.checked;
-    try {
-      const updatedGrower = { id: grower.id, show_in_map: toggle };
-      await updateGrower(updatedGrower);
-    } catch (error) {
-      setErrorMessage('Error updating grower detail');
-    }
+  React.useEffect(() => {
+    setShowInMap(!!grower?.show_in_map);
+  }, [grower?.show_in_map]);
+
+  const toggleShow = async () => {
+    const newShowState = !showInMap;
+    setShowInMap(newShowState);
+    await updateGrower({ id: grower.id, show_in_map: newShowState });
   };
+
   return (
     <Grid
       container
@@ -609,10 +608,7 @@ const ShowInMapToggle = ({ grower, setErrorMessage }) => {
       }}
     >
       <Typography variant="subtitle1">Show in map</Typography>
-      <Switch
-        checked={grower?.show_in_map || false}
-        onChange={handleSwitchChange}
-      />
+      <Switch checked={showInMap} onChange={toggleShow} />
     </Grid>
   );
 };

--- a/src/components/GrowerDetail.js
+++ b/src/components/GrowerDetail.js
@@ -17,6 +17,7 @@ import {
   Divider,
   LinearProgress,
   Fab,
+  Switch,
 } from '@material-ui/core';
 import {
   Close,
@@ -410,6 +411,11 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
                   </Grid>
                 )}
               <Divider />
+              <ShowInMapToggle
+                grower={grower}
+                setErrorMessage={setErrorMessage}
+              />
+              <Divider />
               <Grid container direction="column" className={classes.box}>
                 <Typography variant="subtitle1" className={classes.captures}>
                   Captures
@@ -578,3 +584,35 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
 };
 
 export default GrowerDetail;
+
+const ShowInMapToggle = ({ grower, setErrorMessage }) => {
+  const classes = useStyle();
+  const { updateGrower } = useContext(GrowerContext);
+
+  const handleSwitchChange = async (e) => {
+    const toggle = e.target.checked;
+    try {
+      const updatedGrower = { id: grower.id, show_in_map: toggle };
+      await updateGrower(updatedGrower);
+    } catch (error) {
+      setErrorMessage('Error updating grower detail');
+    }
+  };
+  return (
+    <Grid
+      container
+      direction="row"
+      className={classes.box}
+      style={{
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}
+    >
+      <Typography variant="subtitle1">Show in map</Typography>
+      <Switch
+        checked={grower?.show_in_map || false}
+        onChange={handleSwitchChange}
+      />
+    </Grid>
+  );
+};

--- a/src/context/GrowerContext.js
+++ b/src/context/GrowerContext.js
@@ -86,10 +86,10 @@ export function GrowerProvider(props) {
     const updatedGrower = await api.getGrower(payload.id);
     const index = growers.findIndex((p) => p.id === updatedGrower.id);
     if (index >= 0) {
-      const growers = Object.assign([], growers, {
+      const newGrowers = Object.assign([], growers, {
         [index]: updatedGrower,
       });
-      setGrowers(growers);
+      setGrowers(newGrowers);
     }
   };
 


### PR DESCRIPTION
## Description 
This addresses the issue #1038 by adding the toggle switch on the grower detail. 

https://github.com/user-attachments/assets/1d336a69-29f2-492d-b13f-8a4da1c9a32b

NOTE: There is a flick when the toggle is interacted with because the existing useEffect is listening to the growers state changing. I think this is something that can be improved but it will need a bit of a refactor and out of scope for this change. I can help write a separate issue for it later. 

Also, I want to give credit to this [existing MR](https://github.com/Greenstand/treetracker-admin-client/pull/1104) in the past (2023), copy pasted the UI from this. 

--------------------------------------------------------------------------------------------

**What kind of change(s) does this PR introduce?**

- [x] Enhancement
- [ ] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**

**What is the new behavior?**

## Breaking change

**Does this PR introduce a breaking change?**

## Other useful information

- BE Model Change: https://github.com/Greenstand/treetracker-admin-api/pull/664