### PR TITLE
fix: resolve species page reload failed error

### DIFF
--- a/src/components/SpeciesTable.js
+++ b/src/components/SpeciesTable.js
@@ -142,6 +142,10 @@ const SpeciesTable = (props) => {
   const tableRef = useRef(null);
 
   useEffect(() => {
+    speciesContext.ensureLoaded?.();
+  }, []);
+
+  useEffect(() => {
     const sortBy = (option) => {
       let sortedSpecies;
       if (option === sortOptions.byId) {


### PR DESCRIPTION
## Description

- Fixes an issue where the Species page shows no data after a full page refresh. 

- The React Query cache is in-memory and gets cleared on refresh, but `SpeciesTable` had no mechanism to trigger a fetch on mount — `ensureLoaded()` was only called from the `Species` dropdown component, not the table itself.

- Added a `useEffect` in `SpeciesTable` to call `ensureLoaded()` on mount, which fetches from the API when the cache is empty and is a no-op when cached data already exists.

**Issue(s) addressed**

- Resolves #1191 

**What kind of change(s) does this PR introduce?**

- [x] Bug fix

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**

Navigating to the Species page for the first time shows data correctly. However, refreshing the page results in an empty table with no error in the console.

**What is the new behavior?**

https://github.com/user-attachments/assets/1476dc8a-c986-4016-aea6-80d141ee3daa

The Species page correctly loads and displays species data after a full page refresh.

<!-- Add screenshots here -->

## Breaking change

**Does this PR introduce a breaking change?**

No.

## Other useful information

Root cause: `SpeciesContext` uses `enabled: false` in `useQuery` to prevent auto-fetching. `SpeciesTable` relied on the React Query cache being pre-populated by prior navigation, which is cleared on refresh.
