### PR TITLE
fix: show device identifier in grower detail when registration is empty

### DIFF
--- a/src/components/GrowerDetail.js
+++ b/src/components/GrowerDetail.js
@@ -133,6 +133,91 @@ const useStyle = makeStyles((theme) => ({
   },
 }));
 
+const CAPTURE_DEVICE_LOOKUP_LIMIT = 100;
+
+const isPresentDeviceIdentifier = (value) => {
+  if (value == null) return false;
+  return String(value).trim().length > 0;
+};
+
+const getRegistrationDeviceIdentifier = (reg) => {
+  if (!reg) return undefined;
+  const candidates = [
+    reg.device_identifier,
+    reg.deviceIdentifier,
+    reg.field_data?.device_identifier,
+    reg.field_data?.deviceIdentifier,
+    reg.fieldData?.device_identifier,
+    reg.fieldData?.deviceIdentifier,
+  ];
+  return candidates.find(isPresentDeviceIdentifier);
+};
+
+const getRegistrationManufacturer = (reg) => {
+  if (!reg) return undefined;
+  return (
+    reg.manufacturer ??
+    reg.field_data?.manufacturer ??
+    reg.fieldData?.manufacturer
+  );
+};
+
+const inferOsLabelFromDeviceIdentifier = (deviceIdentifier) => {
+  if (!deviceIdentifier) return 'Unknown';
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(deviceIdentifier)) {
+    return 'iOS';
+  }
+  if (/^[0-9a-f]{16}$/i.test(deviceIdentifier)) {
+    return 'Android';
+  }
+  return 'Unknown';
+};
+
+const buildDeviceIdentifiersFromRegistrations = (registrations) => {
+  const uniqueDevices = {};
+  return registrations.reduce((result, reg) => {
+    const deviceIdentifier = getRegistrationDeviceIdentifier(reg);
+    if (
+      !isPresentDeviceIdentifier(deviceIdentifier) ||
+      uniqueDevices[deviceIdentifier]
+    ) {
+      return result;
+    }
+    uniqueDevices[deviceIdentifier] = true;
+    const manufacturer = getRegistrationManufacturer(reg);
+    const os =
+      manufacturer?.toLowerCase() === 'apple'
+        ? 'iOS'
+        : manufacturer
+        ? 'Android'
+        : inferOsLabelFromDeviceIdentifier(deviceIdentifier);
+    result.push({
+      id: deviceIdentifier,
+      os,
+    });
+    return result;
+  }, []);
+};
+
+const buildDeviceIdentifiersFromCaptures = (captures) => {
+  const uniqueDevices = {};
+  return captures.reduce((result, capture) => {
+    const deviceIdentifier = capture.deviceIdentifier;
+    if (
+      !isPresentDeviceIdentifier(deviceIdentifier) ||
+      uniqueDevices[deviceIdentifier]
+    ) {
+      return result;
+    }
+    uniqueDevices[deviceIdentifier] = true;
+    result.push({
+      id: deviceIdentifier,
+      os: inferOsLabelFromDeviceIdentifier(deviceIdentifier),
+    });
+    return result;
+  }, []);
+};
+
 const GrowerDetail = ({ open, growerId, onClose }) => {
   // console.log('render: grower detail');
   const classes = useStyle();
@@ -140,6 +225,7 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
   const { growers } = useContext(GrowerContext);
   const { sendMessageFromGrower } = useContext(MessagingContext);
   const [growerRegistrations, setGrowerRegistrations] = useState(null);
+  const [registrationsPlanterId, setRegistrationsPlanterId] = useState(null);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [grower, setGrower] = useState({});
   const [deviceIdentifiers, setDeviceIdentifiers] = useState([]);
@@ -148,6 +234,19 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
   const [verificationStatus, setVerificationStatus] = useState({});
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
+
+  async function loadDeviceIdentifiersFromCaptures(planterId) {
+    const filter = new FilterModel();
+    filter.planterId = planterId?.toString();
+    const captures = await treeTrackerApi.getCaptureImages({
+      skip: 0,
+      rowsPerPage: CAPTURE_DEVICE_LOOKUP_LIMIT,
+      orderBy: 'timeCreated',
+      order: 'desc',
+      filter,
+    });
+    return buildDeviceIdentifiersFromCaptures(captures || []);
+  }
 
   useEffect(() => {
     setErrorMessage(null);
@@ -176,41 +275,34 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
 
         setGrower(match);
 
-        if (
-          match.id &&
-          (!growerRegistrations ||
-            (growerRegistrations.length > 0 &&
-              growerRegistrations[0].planter_id !== match.id))
-        ) {
+        const planterId = match.id;
+        if (planterId && Number(registrationsPlanterId) !== Number(planterId)) {
           setGrowerRegistrations(null);
-          api.getGrowerRegistrations(match.id).then((registrations) => {
-            if (registrations && registrations.length) {
-              const sortedReg = registrations.sort((a, b) =>
-                a.created_at > b.created_at ? 1 : -1
-              );
-              const uniqueDevices = {};
-              const devices = sortedReg.reduce((result, reg) => {
-                if (!reg.device_identifier) {
-                  return result;
-                }
-                if (!uniqueDevices[reg.device_identifier]) {
-                  uniqueDevices[reg.device_identifier] = true;
-                  // if manufacturer isn't 'apple' it's an android phone
-                  result.push({
-                    id: reg.device_identifier,
-                    os:
-                      reg.manufacturer?.toLowerCase() === 'apple'
-                        ? 'iOS'
-                        : 'Android',
-                  });
-                }
-                return result;
-              }, []);
+          setDeviceIdentifiers([]);
+          api
+            .getGrowerRegistrations(planterId)
+            .then(async (registrations) => {
+              const sortedReg =
+                registrations && registrations.length
+                  ? [...registrations].sort((a, b) =>
+                      a.created_at > b.created_at ? 1 : -1
+                    )
+                  : [];
 
-              setDeviceIdentifiers(devices);
+              let devices = buildDeviceIdentifiersFromRegistrations(sortedReg);
+              if (!devices.length) {
+                devices = await loadDeviceIdentifiersFromCaptures(planterId);
+              }
+
+              setRegistrationsPlanterId(planterId);
               setGrowerRegistrations(sortedReg);
-            }
-          });
+              setDeviceIdentifiers(devices);
+            })
+            .catch(() => {
+              setRegistrationsPlanterId(planterId);
+              setGrowerRegistrations([]);
+              setDeviceIdentifiers([]);
+            });
         }
       }
     }


### PR DESCRIPTION
## Description

Grower detail only loaded device identifiers from `planter-registration`. For many growers (especially when registration rows are missing or lack `device_identifier`), the identifier still exists on captures (`trees.deviceIdentifier`), so the UI showed `---` even though the API had data.

This PR:

- Keeps registration as the primary source and reads alternate field shapes (`device_identifier`, `deviceIdentifier`, nested `field_data` / `fieldData`).
- Falls back to deduped device identifiers from the grower’s most recent captures (up to 100) when registration returns none.
- Fixes grower switching when the previous grower had an empty registration array (reload did not run).
- Handles registration fetch errors without leaving stale device-id state.

**Admin-only workaround** — does not fix missing `device_identifier` on `planter-registration` in field-data / bulk-pack ingestion (follow-up on backend).

**Issue(s) addressed**

- Resolves #1194

**What kind of change(s) does this PR introduce?**

- [ ] Enhancement
- [x] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**

Grower detail shows device identifiers only from `GET .../planter-registration`. If that list is empty or rows lack `device_identifier`, the Device Identifier section shows `---`, even when the grower’s captures include `deviceIdentifier` (e.g. dev growers **22711**, **22707**). Switching between growers after viewing one with empty registrations could also leave device IDs stale.

**What is the new behavior?**

Device identifiers are built from registrations when present; otherwise from recent captures. Opening a different grower reloads registration (and capture fallback when needed) correctly. OS label uses manufacturer when available, with shape-based inference for capture fallback.

## Breaking change

**Does this PR introduce a breaking change?**

No.

## Other useful information

**Test plan (dev-k8s)**

- [ ] Grower **22711** — empty `planter-registration`, captures have `deviceIdentifier` → identifier visible in Grower detail.
- [ ] Grower **22707** — same pattern.
- [ ] Grower with registration device ids (e.g. **22716**) — no regression.
- [ ] Open grower A, then grower B — device ids update for B.

**Follow-up (out of scope)**

- Persist/serve `device_identifier` on `planter-registration` (bulk-pack / field-data pipeline).
- Re-test reporter grower **20692** on prod (not on dev-k8s).
- Optional: Growers list filter applies `deviceIdentifier: null` when Device ID filter is empty.

Manual testing on dev-k8s; no new unit tests added.
