### PR TITLE
feat(subscription): add subscription plans page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treetracker-admin-client",
-  "version": "1.107.5-hotfix.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "treetracker-admin-client",
-      "version": "1.107.5-hotfix.2",
+      "version": "2.0.0",
       "dependencies": {
         "@date-io/date-fns": "^1.3.13",
         "@material-ui/core": "^4.9.10",
@@ -21828,8 +21828,6 @@
     },
     "node_modules/npm/node_modules/@colors/colors": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -21839,13 +21837,11 @@
     },
     "node_modules/npm/node_modules/@gar/promisify": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
       "inBundle": true,
       "license": "ISC"
     },
@@ -21898,7 +21894,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/ci-detect": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-2.0.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -21925,7 +21920,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/disparity-colors/-/disparity-colors-2.0.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -21968,7 +21962,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22024,13 +22017,11 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-1.0.1.tgz",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-2.0.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -22039,7 +22030,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-2.0.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22051,7 +22041,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-3.0.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22077,7 +22066,6 @@
     },
     "node_modules/npm/node_modules/@tootallnate/once": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22086,14 +22074,11 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22105,7 +22090,6 @@
     },
     "node_modules/npm/node_modules/agentkeepalive": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22119,8 +22103,6 @@
     },
     "node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22133,8 +22115,6 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22143,8 +22123,6 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22159,13 +22137,11 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "inBundle": true,
       "license": "MIT"
     },
@@ -22183,14 +22159,11 @@
     },
     "node_modules/npm/node_modules/asap": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "inBundle": true,
       "license": "MIT"
     },
@@ -22212,7 +22185,6 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22221,8 +22193,6 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22231,7 +22201,6 @@
     },
     "node_modules/npm/node_modules/builtins": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22268,8 +22237,6 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22285,8 +22252,6 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -22295,7 +22260,6 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-3.1.1.tgz",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -22307,8 +22271,6 @@
     },
     "node_modules/npm/node_modules/clean-stack": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22317,7 +22279,6 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-4.0.0.tgz",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22344,7 +22305,6 @@
     },
     "node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22353,7 +22313,6 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-5.0.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22365,8 +22324,6 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22378,14 +22335,11 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/color-support": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -22394,7 +22348,6 @@
     },
     "node_modules/npm/node_modules/columnify": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.6.0.tgz",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22407,28 +22360,21 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22450,7 +22396,6 @@
     },
     "node_modules/npm/node_modules/debuglog": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22459,7 +22404,6 @@
     },
     "node_modules/npm/node_modules/defaults": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22468,14 +22412,11 @@
     },
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/depd": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22484,7 +22425,6 @@
     },
     "node_modules/npm/node_modules/dezalgo": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22502,14 +22442,11 @@
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -22519,7 +22456,6 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22528,7 +22464,6 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "inBundle": true,
       "license": "MIT"
     },
@@ -22539,8 +22474,6 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22552,21 +22485,16 @@
     },
     "node_modules/npm/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22585,7 +22513,6 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22604,15 +22531,11 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22624,8 +22547,6 @@
     },
     "node_modules/npm/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22634,8 +22555,6 @@
     },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "inBundle": true,
       "license": "ISC"
     },
@@ -22652,13 +22571,11 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22672,8 +22589,6 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22686,7 +22601,6 @@
     },
     "node_modules/npm/node_modules/humanize-ms": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22695,8 +22609,6 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -22709,7 +22621,6 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-5.0.1.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22721,8 +22632,6 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22731,8 +22640,6 @@
     },
     "node_modules/npm/node_modules/indent-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22741,15 +22648,11 @@
     },
     "node_modules/npm/node_modules/infer-owner": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22759,8 +22662,6 @@
     },
     "node_modules/npm/node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "inBundle": true,
       "license": "ISC"
     },
@@ -22774,7 +22675,6 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-3.0.2.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -22797,7 +22697,6 @@
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22806,7 +22705,6 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-4.0.2.tgz",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -22818,8 +22716,6 @@
     },
     "node_modules/npm/node_modules/is-core-module": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22831,8 +22727,6 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -22841,27 +22735,21 @@
     },
     "node_modules/npm/node_modules/is-lambda": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -22870,7 +22758,6 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "engines": [
         "node >= 0.2.0"
       ],
@@ -23078,8 +22965,6 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23102,8 +22987,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23131,8 +23014,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23144,7 +23025,6 @@
     },
     "node_modules/npm/node_modules/minipass-json-stream": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minipass-json-stream/-/minipass-json-stream-1.0.1.tgz",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23154,7 +23034,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23166,7 +23045,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23178,8 +23056,6 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23192,8 +23068,6 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -23205,7 +23079,6 @@
     },
     "node_modules/npm/node_modules/mkdirp-infer-owner": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23219,19 +23092,16 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23263,8 +23133,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23293,8 +23161,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23306,7 +23172,6 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23335,7 +23200,6 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-3.0.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23347,7 +23211,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23356,7 +23219,6 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-5.0.0.tgz",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -23368,7 +23230,6 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
       "inBundle": true,
       "license": "ISC"
     },
@@ -23447,13 +23308,11 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.1.tgz",
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/npmlog": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23468,8 +23327,6 @@
     },
     "node_modules/npm/node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23478,7 +23335,6 @@
     },
     "node_modules/npm/node_modules/opener": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
       "inBundle": true,
       "license": "(WTFPL OR MIT)",
       "bin": {
@@ -23487,8 +23343,6 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23537,7 +23391,6 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-2.0.2.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23551,8 +23404,6 @@
     },
     "node_modules/npm/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23561,7 +23412,6 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -23570,7 +23420,6 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -23579,7 +23428,6 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-1.0.1.tgz",
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -23588,14 +23436,11 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23608,7 +23453,6 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23617,7 +23461,6 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -23625,7 +23468,6 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23659,7 +23501,6 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.3.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23672,8 +23513,6 @@
     },
     "node_modules/npm/node_modules/readable-stream": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23687,7 +23526,6 @@
     },
     "node_modules/npm/node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23699,7 +23537,6 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23708,8 +23545,6 @@
     },
     "node_modules/npm/node_modules/rimraf": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23724,8 +23559,6 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23754,8 +23587,6 @@
     },
     "node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23767,8 +23598,6 @@
     },
     "node_modules/npm/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -23788,16 +23617,12 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23823,20 +23648,16 @@
     },
     "node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23859,7 +23680,6 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23873,8 +23693,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -23884,15 +23702,11 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23902,14 +23716,11 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23921,8 +23732,6 @@
     },
     "node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23931,8 +23740,6 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23946,8 +23753,6 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23959,8 +23764,6 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -23972,7 +23775,6 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -23989,19 +23791,16 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-2.0.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -24010,8 +23809,6 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -24020,8 +23817,6 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -24030,14 +23825,11 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -24047,7 +23839,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -24059,13 +23850,11 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-1.0.0.tgz",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24074,7 +23863,6 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -24089,7 +23877,6 @@
     },
     "node_modules/npm/node_modules/wide-align": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -24098,8 +23885,6 @@
     },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "inBundle": true,
       "license": "ISC"
     },
@@ -24117,8 +23902,6 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "inBundle": true,
       "license": "ISC"
     },
@@ -51612,19 +51395,15 @@
       "dependencies": {
         "@colors/colors": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-          "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
           "bundled": true,
           "optional": true
         },
         "@gar/promisify": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
           "bundled": true
         },
         "@isaacs/string-locale-compare": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
           "bundled": true
         },
         "@npmcli/arborist": {
@@ -51669,7 +51448,6 @@
         },
         "@npmcli/ci-detect": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-2.0.0.tgz",
           "bundled": true
         },
         "@npmcli/config": {
@@ -51688,7 +51466,6 @@
         },
         "@npmcli/disparity-colors": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@npmcli/disparity-colors/-/disparity-colors-2.0.0.tgz",
           "bundled": true,
           "requires": {
             "ansi-styles": "^4.3.0"
@@ -51719,7 +51496,6 @@
         },
         "@npmcli/installed-package-contents": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz",
           "bundled": true,
           "requires": {
             "npm-bundled": "^1.1.1",
@@ -51756,17 +51532,14 @@
         },
         "@npmcli/name-from-folder": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-1.0.1.tgz",
           "bundled": true
         },
         "@npmcli/node-gyp": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-2.0.0.tgz",
           "bundled": true
         },
         "@npmcli/package-json": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-2.0.0.tgz",
           "bundled": true,
           "requires": {
             "json-parse-even-better-errors": "^2.3.1"
@@ -51774,7 +51547,6 @@
         },
         "@npmcli/promise-spawn": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-3.0.0.tgz",
           "bundled": true,
           "requires": {
             "infer-owner": "^1.0.4"
@@ -51792,18 +51564,14 @@
         },
         "@tootallnate/once": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
           "bundled": true
         },
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "bundled": true
         },
         "agent-base": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
           "bundled": true,
           "requires": {
             "debug": "4"
@@ -51811,7 +51579,6 @@
         },
         "agentkeepalive": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
           "bundled": true,
           "requires": {
             "debug": "^4.1.0",
@@ -51821,8 +51588,6 @@
         },
         "aggregate-error": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
           "bundled": true,
           "requires": {
             "clean-stack": "^2.0.0",
@@ -51831,14 +51596,10 @@
         },
         "ansi-regex": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "bundled": true
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "bundled": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -51846,12 +51607,10 @@
         },
         "aproba": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
           "bundled": true
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
           "bundled": true
         },
         "are-we-there-yet": {
@@ -51864,13 +51623,10 @@
         },
         "asap": {
           "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
           "bundled": true
         },
         "balanced-match": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
           "bundled": true
         },
         "bin-links": {
@@ -51887,13 +51643,10 @@
         },
         "binary-extensions": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
           "bundled": true
         },
         "brace-expansion": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "bundled": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -51901,7 +51654,6 @@
         },
         "builtins": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
           "bundled": true,
           "requires": {
             "semver": "^7.0.0"
@@ -51933,8 +51685,6 @@
         },
         "chalk": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "bundled": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -51943,13 +51693,10 @@
         },
         "chownr": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
           "bundled": true
         },
         "cidr-regex": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-3.1.1.tgz",
           "bundled": true,
           "requires": {
             "ip-regex": "^4.1.0"
@@ -51957,13 +51704,10 @@
         },
         "clean-stack": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
           "bundled": true
         },
         "cli-columns": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-4.0.0.tgz",
           "bundled": true,
           "requires": {
             "string-width": "^4.2.3",
@@ -51980,12 +51724,10 @@
         },
         "clone": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
           "bundled": true
         },
         "cmd-shim": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-5.0.0.tgz",
           "bundled": true,
           "requires": {
             "mkdirp-infer-owner": "^2.0.0"
@@ -51993,8 +51735,6 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "bundled": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -52002,18 +51742,14 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "bundled": true
         },
         "color-support": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
           "bundled": true
         },
         "columnify": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.6.0.tgz",
           "bundled": true,
           "requires": {
             "strip-ansi": "^6.0.1",
@@ -52022,25 +51758,18 @@
         },
         "common-ancestor-path": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
           "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
           "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
           "bundled": true
         },
         "debug": {
           "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "bundled": true,
           "requires": {
             "ms": "2.1.2"
@@ -52054,12 +51783,10 @@
         },
         "debuglog": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
           "bundled": true
         },
         "defaults": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
           "bundled": true,
           "requires": {
             "clone": "^1.0.2"
@@ -52067,18 +51794,14 @@
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
           "bundled": true
         },
         "depd": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "bundled": true
         },
         "dezalgo": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
           "bundled": true,
           "requires": {
             "asap": "^2.0.0",
@@ -52091,13 +51814,10 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "bundled": true
         },
         "encoding": {
           "version": "0.1.13",
-          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -52106,12 +51826,10 @@
         },
         "env-paths": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
           "bundled": true
         },
         "err-code": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
           "bundled": true
         },
         "fastest-levenshtein": {
@@ -52120,8 +51838,6 @@
         },
         "fs-minipass": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
           "bundled": true,
           "requires": {
             "minipass": "^3.0.0"
@@ -52129,19 +51845,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
           "bundled": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
           "bundled": true
         },
         "gauge": {
           "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
           "bundled": true,
           "requires": {
             "aproba": "^1.0.3 || ^2.0.0",
@@ -52156,7 +51867,6 @@
         },
         "glob": {
           "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
           "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -52168,14 +51878,10 @@
         },
         "graceful-fs": {
           "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
           "bundled": true
         },
         "has": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "bundled": true,
           "requires": {
             "function-bind": "^1.1.1"
@@ -52183,14 +51889,10 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "bundled": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
           "bundled": true
         },
         "hosted-git-info": {
@@ -52202,12 +51904,10 @@
         },
         "http-cache-semantics": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
           "bundled": true
         },
         "http-proxy-agent": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
           "bundled": true,
           "requires": {
             "@tootallnate/once": "2",
@@ -52217,8 +51917,6 @@
         },
         "https-proxy-agent": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
           "bundled": true,
           "requires": {
             "agent-base": "6",
@@ -52227,7 +51925,6 @@
         },
         "humanize-ms": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
           "bundled": true,
           "requires": {
             "ms": "^2.0.0"
@@ -52235,8 +51932,6 @@
         },
         "iconv-lite": {
           "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -52245,7 +51940,6 @@
         },
         "ignore-walk": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-5.0.1.tgz",
           "bundled": true,
           "requires": {
             "minimatch": "^5.0.1"
@@ -52253,26 +51947,18 @@
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
           "bundled": true
         },
         "indent-string": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
           "bundled": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-          "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
           "bundled": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
           "bundled": true,
           "requires": {
             "once": "^1.3.0",
@@ -52281,8 +51967,6 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "bundled": true
         },
         "ini": {
@@ -52291,7 +51975,6 @@
         },
         "init-package-json": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-3.0.2.tgz",
           "bundled": true,
           "requires": {
             "npm-package-arg": "^9.0.1",
@@ -52309,12 +51992,10 @@
         },
         "ip-regex": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
           "bundled": true
         },
         "is-cidr": {
           "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-4.0.2.tgz",
           "bundled": true,
           "requires": {
             "cidr-regex": "^3.1.1"
@@ -52322,8 +52003,6 @@
         },
         "is-core-module": {
           "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-          "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
           "bundled": true,
           "requires": {
             "has": "^1.0.3"
@@ -52331,35 +52010,26 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "bundled": true
         },
         "is-lambda": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
           "bundled": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
           "bundled": true
         },
         "json-parse-even-better-errors": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-          "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
           "bundled": true
         },
         "json-stringify-nice": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
           "bundled": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
           "bundled": true
         },
         "just-diff": {
@@ -52509,8 +52179,6 @@
         },
         "minimatch": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
           "bundled": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -52525,8 +52193,6 @@
         },
         "minipass-collect": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-          "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
           "bundled": true,
           "requires": {
             "minipass": "^3.0.0"
@@ -52544,8 +52210,6 @@
         },
         "minipass-flush": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-          "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
           "bundled": true,
           "requires": {
             "minipass": "^3.0.0"
@@ -52553,7 +52217,6 @@
         },
         "minipass-json-stream": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/minipass-json-stream/-/minipass-json-stream-1.0.1.tgz",
           "bundled": true,
           "requires": {
             "jsonparse": "^1.3.1",
@@ -52562,7 +52225,6 @@
         },
         "minipass-pipeline": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
           "bundled": true,
           "requires": {
             "minipass": "^3.0.0"
@@ -52570,7 +52232,6 @@
         },
         "minipass-sized": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
           "bundled": true,
           "requires": {
             "minipass": "^3.0.0"
@@ -52578,8 +52239,6 @@
         },
         "minizlib": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
           "bundled": true,
           "requires": {
             "minipass": "^3.0.0",
@@ -52588,13 +52247,10 @@
         },
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "bundled": true
         },
         "mkdirp-infer-owner": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz",
           "bundled": true,
           "requires": {
             "chownr": "^2.0.0",
@@ -52604,17 +52260,14 @@
         },
         "ms": {
           "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "bundled": true
         },
         "mute-stream": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
           "bundled": true
         },
         "negotiator": {
           "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
           "bundled": true
         },
         "node-gyp": {
@@ -52635,8 +52288,6 @@
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "bundled": true,
               "requires": {
                 "balanced-match": "^1.0.0",
@@ -52657,8 +52308,6 @@
             },
             "minimatch": {
               "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
               "bundled": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
@@ -52668,7 +52317,6 @@
         },
         "nopt": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
           "bundled": true,
           "requires": {
             "abbrev": "1"
@@ -52686,7 +52334,6 @@
         },
         "npm-audit-report": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-3.0.0.tgz",
           "bundled": true,
           "requires": {
             "chalk": "^4.0.0"
@@ -52694,7 +52341,6 @@
         },
         "npm-bundled": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
           "bundled": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
@@ -52702,7 +52348,6 @@
         },
         "npm-install-checks": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-5.0.0.tgz",
           "bundled": true,
           "requires": {
             "semver": "^7.1.1"
@@ -52710,7 +52355,6 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
           "bundled": true
         },
         "npm-package-arg": {
@@ -52765,12 +52409,10 @@
         },
         "npm-user-validate": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.1.tgz",
           "bundled": true
         },
         "npmlog": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
           "bundled": true,
           "requires": {
             "are-we-there-yet": "^3.0.0",
@@ -52781,8 +52423,6 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
           "bundled": true,
           "requires": {
             "wrappy": "1"
@@ -52790,13 +52430,10 @@
         },
         "opener": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
           "bundled": true
         },
         "p-map": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
           "bundled": true,
           "requires": {
             "aggregate-error": "^3.0.0"
@@ -52831,7 +52468,6 @@
         },
         "parse-conflict-json": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-2.0.2.tgz",
           "bundled": true,
           "requires": {
             "json-parse-even-better-errors": "^2.3.1",
@@ -52841,34 +52477,26 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
           "bundled": true
         },
         "proc-log": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
           "bundled": true
         },
         "promise-all-reject-late": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
           "bundled": true
         },
         "promise-call-limit": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-1.0.1.tgz",
           "bundled": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-          "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
           "bundled": true
         },
         "promise-retry": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
           "bundled": true,
           "requires": {
             "err-code": "^2.0.2",
@@ -52877,7 +52505,6 @@
         },
         "promzard": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
           "bundled": true,
           "requires": {
             "read": "1"
@@ -52885,12 +52512,10 @@
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
           "bundled": true
         },
         "read": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
           "bundled": true,
           "requires": {
             "mute-stream": "~0.0.4"
@@ -52912,7 +52537,6 @@
         },
         "read-package-json-fast": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.3.tgz",
           "bundled": true,
           "requires": {
             "json-parse-even-better-errors": "^2.3.0",
@@ -52921,8 +52545,6 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "bundled": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -52932,7 +52554,6 @@
         },
         "readdir-scoped-modules": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
           "bundled": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -52943,13 +52564,10 @@
         },
         "retry": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
           "bundled": true
         },
         "rimraf": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "bundled": true,
           "requires": {
             "glob": "^7.1.3"
@@ -52957,8 +52575,6 @@
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "bundled": true,
               "requires": {
                 "balanced-match": "^1.0.0",
@@ -52979,8 +52595,6 @@
             },
             "minimatch": {
               "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
               "bundled": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
@@ -52990,21 +52604,15 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "bundled": true,
           "optional": true
         },
         "semver": {
           "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -53021,18 +52629,14 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
           "bundled": true
         },
         "signal-exit": {
           "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
           "bundled": true
         },
         "smart-buffer": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
           "bundled": true
         },
         "socks": {
@@ -53045,7 +52649,6 @@
         },
         "socks-proxy-agent": {
           "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
           "bundled": true,
           "requires": {
             "agent-base": "^6.0.2",
@@ -53055,8 +52658,6 @@
         },
         "spdx-correct": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-          "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
           "bundled": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -53065,14 +52666,10 @@
         },
         "spdx-exceptions": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-          "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
           "bundled": true
         },
         "spdx-expression-parse": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-          "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
           "bundled": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -53081,13 +52678,10 @@
         },
         "spdx-license-ids": {
           "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-          "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
           "bundled": true
         },
         "ssri": {
           "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
           "bundled": true,
           "requires": {
             "minipass": "^3.1.1"
@@ -53095,8 +52689,6 @@
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "bundled": true,
           "requires": {
             "safe-buffer": "~5.2.0"
@@ -53104,8 +52696,6 @@
         },
         "string-width": {
           "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "bundled": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -53115,8 +52705,6 @@
         },
         "strip-ansi": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "bundled": true,
           "requires": {
             "ansi-regex": "^5.0.1"
@@ -53124,8 +52712,6 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "bundled": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -53133,7 +52719,6 @@
         },
         "tar": {
           "version": "6.1.11",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
           "bundled": true,
           "requires": {
             "chownr": "^2.0.0",
@@ -53146,23 +52731,18 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
           "bundled": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
           "bundled": true
         },
         "treeverse": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-2.0.0.tgz",
           "bundled": true
         },
         "unique-filename": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-          "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
           "bundled": true,
           "requires": {
             "unique-slug": "^2.0.0"
@@ -53170,8 +52750,6 @@
         },
         "unique-slug": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-          "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
           "bundled": true,
           "requires": {
             "imurmurhash": "^0.1.4"
@@ -53179,13 +52757,10 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
           "bundled": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "bundled": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -53194,7 +52769,6 @@
         },
         "validate-npm-package-name": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
           "bundled": true,
           "requires": {
             "builtins": "^5.0.0"
@@ -53202,12 +52776,10 @@
         },
         "walk-up-path": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-1.0.0.tgz",
           "bundled": true
         },
         "wcwidth": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
           "bundled": true,
           "requires": {
             "defaults": "^1.0.3"
@@ -53215,7 +52787,6 @@
         },
         "which": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "bundled": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -53223,7 +52794,6 @@
         },
         "wide-align": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
           "bundled": true,
           "requires": {
             "string-width": "^1.0.2 || 2 || 3 || 4"
@@ -53231,8 +52801,6 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
           "bundled": true
         },
         "write-file-atomic": {
@@ -53245,8 +52813,6 @@
         },
         "yallist": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "bundled": true
         }
       }

--- a/src/components/Routers.js
+++ b/src/components/Routers.js
@@ -15,6 +15,7 @@ import ReportingCard3 from './reportingCards/ReportingCard3';
 import ReportingCard4 from './reportingCards/ReportingCard4';
 import ReportingCard5 from './reportingCards/ReportingCard5';
 import ReportingCard6 from './reportingCards/ReportingCard6';
+import Subscription from './SubscriptionPlan/Subscription';
 
 export default function Routers() {
   const refContainer = useRef();
@@ -50,6 +51,9 @@ export default function Routers() {
                     pathname: '/growers',
                   }}
                 />
+              </Route>
+              <Route path="/subscription">
+                <Subscription />
               </Route>
               {appContext.routes.map((route, idx) =>
                 route?.children ? (

--- a/src/components/SubscriptionPlan/Subscription.js
+++ b/src/components/SubscriptionPlan/Subscription.js
@@ -1,0 +1,159 @@
+import React, { useEffect } from 'react';
+import {
+  Box,
+  Button,
+  Divider,
+  Grid,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Paper,
+  Typography,
+} from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import CreditCardIcon from '@material-ui/icons/CreditCard';
+import Menu from '../common/Menu';
+import { documentTitle } from '../../common/variables';
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'row',
+    flexWrap: 'nowrap',
+  },
+  rightBox: {
+    height: '100%',
+    padding: theme.spacing(8),
+  },
+  titleBox: {
+    marginBottom: theme.spacing(4),
+  },
+  headlineIcon: {
+    fontSize: '4rem',
+    marginRight: theme.spacing(4),
+    color: 'gray',
+  },
+  subtitle: {
+    color: 'gray',
+    marginTop: theme.spacing(1),
+  },
+  border: {
+    borderBottom: '1px solid #ddd',
+  },
+  card: {
+    maxWidth: 420,
+    padding: theme.spacing(5),
+  },
+  planName: {
+    fontWeight: 700,
+  },
+  priceBox: {
+    display: 'flex',
+    alignItems: 'baseline',
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(3),
+  },
+  price: {
+    fontWeight: 700,
+    color: theme.palette.primary.main,
+  },
+  pricePeriod: {
+    color: 'gray',
+    marginLeft: theme.spacing(1),
+  },
+  featureIcon: {
+    minWidth: theme.spacing(5),
+    color: theme.palette.primary.main,
+  },
+  button: {
+    marginTop: theme.spacing(4),
+    width: '100%',
+    fontSize: '1rem',
+  },
+}));
+
+const BASIC_PLAN = {
+  name: 'Basic',
+  price: '$19',
+  period: 'per month',
+  features: [
+    '50,000 captures',
+    '5 projects',
+    'Analytics access',
+    'Email support',
+    'API access',
+  ],
+};
+
+export default function Subscription() {
+  const classes = useStyles();
+
+  useEffect(() => {
+    document.title = `Subscription - ${documentTitle}`;
+  }, []);
+
+  return (
+    <Grid className={classes.container}>
+      <Paper elevation={3}>
+        <Menu variant="plain" active="Subscription" />
+      </Paper>
+
+      <Grid item style={{ flexGrow: 1 }}>
+        <Grid container className={classes.rightBox}>
+          <Grid item xs={12}>
+            <Grid container className={classes.titleBox} alignItems="center">
+              <CreditCardIcon className={classes.headlineIcon} />
+              <Grid item>
+                <Typography variant="h3">Subscription Plans</Typography>
+                <Typography variant="body1" className={classes.subtitle}>
+                  Choose the plan that fits your organization.
+                </Typography>
+              </Grid>
+            </Grid>
+            <Box className={classes.border} />
+            <Box height={24} />
+
+            <Paper className={classes.card} elevation={3}>
+              <Typography variant="h4" className={classes.planName}>
+                {BASIC_PLAN.name}
+              </Typography>
+
+              <Box className={classes.priceBox}>
+                <Typography variant="h3" className={classes.price}>
+                  {BASIC_PLAN.price}
+                </Typography>
+                <Typography variant="subtitle1" className={classes.pricePeriod}>
+                  {BASIC_PLAN.period}
+                </Typography>
+              </Box>
+
+              <Divider />
+
+              <List>
+                {BASIC_PLAN.features.map((feature) => (
+                  <ListItem key={feature} disableGutters>
+                    <ListItemIcon className={classes.featureIcon}>
+                      <CheckCircleIcon />
+                    </ListItemIcon>
+                    <ListItemText primary={feature} />
+                  </ListItem>
+                ))}
+              </List>
+
+              <Button
+                variant="contained"
+                color="primary"
+                className={classes.button}
+              >
+                Select Plan
+              </Button>
+            </Paper>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+}

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -14,6 +14,7 @@ import Account from '../components/Account';
 import Home from '../components/Home/Home';
 import Users from '../components/Users';
 import SpeciesView from '../views/SpeciesView';
+import Subscription from '../components/SubscriptionPlan/Subscription';
 import { MessagingProvider } from './MessagingContext';
 import Unauthorized from '../components/Unauthorized';
 
@@ -30,6 +31,7 @@ import CategoryIcon from '@material-ui/icons/Category';
 import HomeIcon from '@material-ui/icons/Home';
 import CompareIcon from '@material-ui/icons/Compare';
 import CreditCardIcon from '@material-ui/icons/CreditCard';
+import SubscriptionsIcon from '@material-ui/icons/Subscriptions';
 import InboxRounded from '@material-ui/icons/InboxRounded';
 import MapIcon from '@material-ui/icons/Map';
 import AccountTreeIcon from '@material-ui/icons/AccountTree';
@@ -194,6 +196,13 @@ function getRoutes(user) {
       linkTo: '/account',
       component: Account,
       icon: IconPermIdentity,
+      disabled: false,
+    },
+    {
+      name: 'Subscription',
+      linkTo: '/subscription',
+      component: Subscription,
+      icon: SubscriptionsIcon,
       disabled: false,
     },
     {


### PR DESCRIPTION
## Description

Add a Subscription Plans view displaying the Starter plan, register its route in Routers, and add a Subscription entry to the app navigation.

**Issue(s) addressed**

- Resolves #1210

**What kind of change(s) does this PR introduce?**

- [ ✅] Enhancement
- [ ] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [✅] The commit message follows our guidelines
- [✅] Tests for the changes have been added (for bug fixes / features)
- [✅] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
There is no Subscription Plan details

**What is the new behavior?**
New Subscription Plan tab in Menu with Starter Plan details:
Scenario: Select the Starter subscription plan
Given I am on the organization onboarding page
When I select the Starter plan
Then I should see that the plan is free
And I should see a limit of 100 captures
And I should see a limit of 1 project
And I should see basic analytics
And I should see limited support

## Breaking change

**Does this PR introduce a breaking change?**

## Other useful information
