### PR TITLE
feat(species): restrict species management to super admins

### DIFF
--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -33,7 +33,7 @@ import CreditCardIcon from '@material-ui/icons/CreditCard';
 import InboxRounded from '@material-ui/icons/InboxRounded';
 import MapIcon from '@material-ui/icons/Map';
 import AccountTreeIcon from '@material-ui/icons/AccountTree';
-import { session, hasPermission, POLICIES } from '../models/auth';
+import { session, hasPermission, isSuperAdmin, POLICIES } from '../models/auth';
 import api from '../api/treeTrackerApi';
 import RegionsView from 'views/RegionsView';
 
@@ -138,11 +138,8 @@ function getRoutes(user) {
       linkTo: '/species',
       component: SpeciesView,
       icon: CategoryIcon,
-      //TODO this is temporary, need to add species policy
-      disabled:
-        !hasPermission(user, [POLICIES.SUPER_PERMISSION, POLICIES.LIST_TREE]) ||
-        !user ||
-        user.policy.organization !== undefined,
+      // Global species pool is managed by super admins only.
+      disabled: !isSuperAdmin(user),
     },
     {
       name: 'Stakeholders',

--- a/src/context/SpeciesContext.js
+++ b/src/context/SpeciesContext.js
@@ -15,6 +15,7 @@ export const SpeciesContext = createContext({
   deleteSpecies: () => {},
   combineSpecies: () => {},
   ensureLoaded: () => {},
+  loadSpeciesList: () => {},
 });
 
 export function SpeciesProvider({ children }) {
@@ -35,6 +36,13 @@ export function SpeciesProvider({ children }) {
     if (!cached || cached.length === 0) {
       await refetch();
     }
+  };
+
+  // Force a reload of the species list. The query is disabled by default, so
+  // invalidateQueries alone won't refetch it — callers (add/edit/delete/combine)
+  // rely on this to refresh the table after a mutation.
+  const loadSpeciesList = async () => {
+    await refetch();
   };
 
   // only used by Species dropdown
@@ -96,6 +104,7 @@ export function SpeciesProvider({ children }) {
     deleteSpecies,
     combineSpecies,
     ensureLoaded, // expose to components
+    loadSpeciesList,
   };
 
   return (

--- a/src/models/auth.js
+++ b/src/models/auth.js
@@ -37,6 +37,19 @@ function hasPermission(user, p) {
   }
 }
 
+/*
+ * A super admin has the global SUPER_PERMISSION policy and is not scoped to a
+ * single organization. Used to gate global/platform-wide tools such as the
+ * global species pool.
+ */
+function isSuperAdmin(user) {
+  if (!user) return false;
+  return (
+    hasPermission(user, POLICIES.SUPER_PERMISSION) &&
+    user.policy?.organization === undefined
+  );
+}
+
 function hasFreetownPermission(user) {
   if (!user) return false;
   // // super admin has freetown permission
@@ -57,4 +70,11 @@ const session = () => {
   };
 };
 
-export { PERMISSIONS, POLICIES, hasPermission, hasFreetownPermission, session };
+export {
+  PERMISSIONS,
+  POLICIES,
+  hasPermission,
+  isSuperAdmin,
+  hasFreetownPermission,
+  session,
+};

--- a/src/views/SpeciesView.js
+++ b/src/views/SpeciesView.js
@@ -7,7 +7,7 @@ import { SpeciesProvider } from '../context/SpeciesContext';
 const SpeciesView = () => {
   /* to update html document title */
   useEffect(() => {
-    document.title = `Species - ${documentTitle}`;
+    document.title = `Global Species Pool - ${documentTitle}`;
   }, []);
 
   return (


### PR DESCRIPTION
Gate the /species route to super admins only via a new isSuperAdmin() helper (checks the global SUPER_PERMISSION policy and no organization scope), so add, edit and delete are limited to super admins. Route-level access is enforced through the disabled flag in Routers.

Also expose loadSpeciesList() from SpeciesContext so add/edit/delete/ combine reload the table after a mutation. The query is disabled by default, so invalidateQueries alone won't refetch it; the missing function previously left the delete/edit dialogs open and unrefreshed.

## Description

- Build Super Admin interface to manage global species
- Capabilities: Create, edit species (scientific name, common name, etc.)

**Issue(s) addressed**

- Resolves #1219 

**What kind of change(s) does this PR introduce?**

- Enhancement
- Refactor
- Bug fixes

**Please check if the PR fulfils these requirements**

- [ ✓ ] The commit message follows our guidelines
- [ ✓ ] Tests for the changes have been added (for bug fixes / features)
- [ ✓ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**

**What is the new behavior?**
- Create / edit species
- Maintain canonical dataset (scientific name, common name, etc.)
- Ensure data consistency

## Breaking change

**Does this PR introduce a breaking change?**
No

## Other useful information
