### PR TITLE
fix(verify,captures): resolve placeholder boxes and stuck loading whe…

### DIFF
--- a/src/components/Verify.js
+++ b/src/components/Verify.js
@@ -394,120 +394,119 @@ const Verify = (props) => {
     return false;
   });
 
-  const captureImageItems = captureImages
-    .concat(placeholderImages)
-    .map((capture) => {
-      return (
-        <Grid
-          item
-          key={capture.id}
-          style={{
-            width: `calc(100% / ${capturesPerRow})`,
-          }}
+  const captureImageItems = (verifyContext.isLoading
+    ? placeholderImages
+    : captureImages
+  ).map((capture) => {
+    return (
+      <Grid
+        item
+        key={capture.id}
+        style={{
+          width: `calc(100% / ${capturesPerRow})`,
+        }}
+      >
+        <div
+          className={clsx(
+            classes.cardWrapper,
+            verifyContext.captureImagesSelected[capture.id]
+              ? classes.cardSelected
+              : undefined,
+            capture.placeholder && classes.placeholderCard
+          )}
         >
-          <div
-            className={clsx(
-              classes.cardWrapper,
-              verifyContext.captureImagesSelected[capture.id]
-                ? classes.cardSelected
-                : undefined,
-              capture.placeholder && classes.placeholderCard
-            )}
+          <Tooltip
+            key={capture.id}
+            placement="top"
+            arrow={true}
+            interactive
+            enterDelay={500}
+            enterNextDelay={500}
+            onMouseEnter={() => setDisableHoverListener(false)}
+            disableHoverListener={disableHoverListener}
+            classes={{
+              tooltipPlacementTop: tooltipPositionStyles.tooltipTop,
+            }}
+            title={
+              <CaptureDetailTooltip
+                capture={capture}
+                showCaptureClick={handleShowCaptureDetail}
+              />
+            }
           >
-            <Tooltip
-              key={capture.id}
-              placement="top"
-              arrow={true}
-              interactive
-              enterDelay={500}
-              enterNextDelay={500}
-              onMouseEnter={() => setDisableHoverListener(false)}
-              disableHoverListener={disableHoverListener}
-              classes={{
-                tooltipPlacementTop: tooltipPositionStyles.tooltipTop,
-              }}
-              title={
-                <CaptureDetailTooltip
-                  capture={capture}
-                  showCaptureClick={handleShowCaptureDetail}
-                />
-              }
+            <Card
+              onClick={(e) => handleCaptureClick(e, capture.id)}
+              id={`card_${capture.id}`}
+              className={classes.card}
+              elevation={capture.placeholder ? 0 : 3}
             >
-              <Card
-                onClick={(e) => handleCaptureClick(e, capture.id)}
-                id={`card_${capture.id}`}
-                className={classes.card}
-                elevation={capture.placeholder ? 0 : 3}
-              >
-                <CardContent className={classes.cardContent}>
-                  <Paper className={classes.cardCheckbox} elevation={4}>
-                    {verifyContext.captureImagesSelected[capture.id] && (
-                      <CheckIcon />
-                    )}
-                  </Paper>
-                  <OptimizedImage
-                    src={capture.imageUrl}
-                    width={isImagesLarge ? 400 : 250}
-                    className={classes.cardMedia}
-                    alertWidth="100%"
-                    alertHeight="200%"
-                    alertPosition="absolute"
-                    alertPadding="5rem 0 0 1rem"
-                    alertTitleSize="1.6rem"
-                    alertTextSize="1rem"
-                  />
-                </CardContent>
+              <CardContent className={classes.cardContent}>
+                <Paper className={classes.cardCheckbox} elevation={4}>
+                  {verifyContext.captureImagesSelected[capture.id] && (
+                    <CheckIcon />
+                  )}
+                </Paper>
+                <OptimizedImage
+                  src={capture.imageUrl}
+                  width={isImagesLarge ? 400 : 250}
+                  className={classes.cardMedia}
+                  alertWidth="100%"
+                  alertHeight="200%"
+                  alertPosition="absolute"
+                  alertPadding="5rem 0 0 1rem"
+                  alertTitleSize="1.6rem"
+                  alertTextSize="1rem"
+                />
+              </CardContent>
 
-                <Grid
-                  justifyContent="center"
-                  container
-                  className={classes.cardActions}
-                >
-                  <Grid item>
-                    <IconButton
-                      onClick={(e) => handleShowGrowerDetail(e, capture)}
-                      aria-label={`Grower details`}
-                      title={`Grower details`}
-                    >
-                      <Person color="primary" />
-                    </IconButton>
-                    <IconButton
-                      onClick={(e) => handleShowCaptureDetail(e, capture)}
-                      aria-label={`Capture details`}
-                      title={`Capture details`}
-                    >
-                      <Nature color="primary" />
-                    </IconButton>
-                    <IconButton
-                      variant="link"
-                      href={`${process.env.REACT_APP_WEBMAP_DOMAIN}/?treeid=${capture.id}`}
-                      target="_blank"
-                      onClick={(e) => handleCapturePinClick(e, capture.id)}
-                      aria-label={`Capture location`}
-                      title={`Capture location`}
-                    >
-                      <LocationOn color="primary" />
-                    </IconButton>
-                    <IconButton
-                      variant="link"
-                      href={`${process.env.REACT_APP_WEBMAP_DOMAIN}/?userid=${capture.planterId}`}
-                      target="_blank"
-                      onClick={(e) =>
-                        handleGrowerMapClick(e, capture.planterId)
-                      }
-                      aria-label={`Grower map`}
-                      title={`Grower map`}
-                    >
-                      <Map color="primary" />
-                    </IconButton>
-                  </Grid>
+              <Grid
+                justifyContent="center"
+                container
+                className={classes.cardActions}
+              >
+                <Grid item>
+                  <IconButton
+                    onClick={(e) => handleShowGrowerDetail(e, capture)}
+                    aria-label={`Grower details`}
+                    title={`Grower details`}
+                  >
+                    <Person color="primary" />
+                  </IconButton>
+                  <IconButton
+                    onClick={(e) => handleShowCaptureDetail(e, capture)}
+                    aria-label={`Capture details`}
+                    title={`Capture details`}
+                  >
+                    <Nature color="primary" />
+                  </IconButton>
+                  <IconButton
+                    variant="link"
+                    href={`${process.env.REACT_APP_WEBMAP_DOMAIN}/?treeid=${capture.id}`}
+                    target="_blank"
+                    onClick={(e) => handleCapturePinClick(e, capture.id)}
+                    aria-label={`Capture location`}
+                    title={`Capture location`}
+                  >
+                    <LocationOn color="primary" />
+                  </IconButton>
+                  <IconButton
+                    variant="link"
+                    href={`${process.env.REACT_APP_WEBMAP_DOMAIN}/?userid=${capture.planterId}`}
+                    target="_blank"
+                    onClick={(e) => handleGrowerMapClick(e, capture.planterId)}
+                    aria-label={`Grower map`}
+                    title={`Grower map`}
+                  >
+                    <Map color="primary" />
+                  </IconButton>
                 </Grid>
-              </Card>
-            </Tooltip>
-          </div>
-        </Grid>
-      );
-    });
+              </Grid>
+            </Card>
+          </Tooltip>
+        </div>
+      </Grid>
+    );
+  });
 
   /*=============================================================*/
 

--- a/src/context/CapturesContext.js
+++ b/src/context/CapturesContext.js
@@ -90,9 +90,12 @@ export function CapturesProvider(props) {
     };
     const paramString = `filter=${JSON.stringify(filterData)}`;
     setIsLoading(true);
-    const response = await queryCapturesApi({ paramString });
-    setIsLoading(false);
-    setCaptures(response.data);
+    try {
+      const response = await queryCapturesApi({ paramString });
+      setCaptures(response.data);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   // GET CAPTURES FOR EXPORT

--- a/src/context/VerifyContext.js
+++ b/src/context/VerifyContext.js
@@ -145,10 +145,12 @@ export function VerifyProvider(props) {
       filter: filter,
     };
     log.debug('load page with params:', pageParams);
-    const result = await api.getCaptureImages(pageParams, abortController);
-    setCaptureImages(result || []);
-    //restore loading status
-    setIsLoading(false);
+    try {
+      const result = await api.getCaptureImages(pageParams, abortController);
+      setCaptureImages(result || []);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const getCaptureSelectedArr = () => {


### PR DESCRIPTION
## Description

- Fixes an issue where the Verify tool displays grey placeholder boxes instead of capture images when filtering results to fewer than 24, and where the Captures module shows a permanent loading spinner if the API request throws an error.
- `Verify.js` was concatenating real images with placeholder boxes during loading. When fewer results than `pageSize` were returned, unfilled placeholder slots remained visible after loading completed.
- Wrapped `api.getCaptureImages` in `try/finally` in `VerifyContext.js` so `setIsLoading(false)` always runs, even when a request is aborted. Previously the missing error handling caused `isLoading` to stay `true` permanently, keeping all 24 placeholder boxes on screen indefinitely.
- Changed rendering in `Verify.js` from concatenating real images with placeholders to an either/or. Meaning, during loading show placeholders only, after loading show real images only.
- Wrapped `queryCapturesApi` in `try/finally` in `CapturesContext.js` so `setIsLoading(false)` always runs, even when the request throws. Previously the missing error handling caused the loading spinner in the Captures table to stay visible permanently.

**Issue(s) addressed**

- Resolves #1111

**What kind of change(s) does this PR introduce?**

- [x] Bug fix

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**

<img width="1919" height="870" alt="bug 2" src="https://github.com/user-attachments/assets/57c88cc9-5b29-4b2e-a139-36ff527ee401" />

<img width="1919" height="874" alt="bug 1" src="https://github.com/user-attachments/assets/e457df98-5342-4b02-a748-1120c802b338" />

Filtering captures to fewer than 24 results causes grey placeholder boxes to appear and stay on screen permanently instead of the actual capture images. This is most commonly triggered by applying a filter while a previous request is still in-flight, which aborts the request and leaves `isLoading` stuck as `true`. The same stuck-loading bug affects the Captures module, where the loading spinner persists permanently if the API request throws.

**What is the new behavior?**
<img width="1919" height="874" alt="fix1" src="https://github.com/user-attachments/assets/265243aa-e879-4bb1-a8e0-94a430d8f7d2" />
<img width="1919" height="876" alt="fix2" src="https://github.com/user-attachments/assets/c86d796f-921a-401e-b505-700bf49f805f" />

Only the actual capture images are shown after loading completes in Verify, with no leftover placeholder boxes. In Captures, the loading spinner correctly clears after the request settles.

## Breaking change

**Does this PR introduce a breaking change?**

No.

## Other useful information

Root cause in Verify: `loadCaptureImages` in `VerifyContext.js` had no `try/finally`, so when a fetch was aborted (e.g. rapid filter changes), `setIsLoading(false)` was never reached and `isLoading` remained `true` indefinitely. Combined with `Verify.js` concatenating real images with placeholder boxes, this resulted in all 24 placeholder boxes staying on screen even after loading completed with fewer results.

Root cause in Captures: `getCapturesAsync` in `CapturesContext.js` had the same missing `try/finally`, so any thrown error during the api request would leave `isLoading` stuck at `true` and the spinner visible permanently.
