### PR TITLE
fix(filters): preserve values when collapsed

### DIFF
--- a/src/components/CaptureFilter.js
+++ b/src/components/CaptureFilter.js
@@ -172,6 +172,7 @@ function Filter(props) {
     filter.tokenId = tokenId;
     filter.verifyStatus = verifyStatus;
     props.onSubmit && props.onSubmit(filter);
+    props.onClick && props.onClick();
   }
 
   function handleReset() {

--- a/src/components/CaptureFilterHeader.js
+++ b/src/components/CaptureFilterHeader.js
@@ -50,14 +50,14 @@ function CaptureFilterHeader(props) {
           </Button>,
         ]}
       >
-        {isFilterShown && (
+        <div style={{ display: isFilterShown ? 'block' : 'none' }}>
           <CaptureFilter
             isOpen={isFilterShown}
             onSubmit={handleFilterSubmit}
             filter={capturesContext.filter}
             onClick={handleFilterClick}
           />
-        )}
+        </div>
       </Navbar>
     </Grid>
   );

--- a/src/components/FilterTop.js
+++ b/src/components/FilterTop.js
@@ -133,6 +133,7 @@ function Filter(props) {
     filter.stakeholderUUID = stakeholderUUID;
     filter.tokenId = tokenId;
     props.onSubmit && props.onSubmit(filter);
+    props.onClose && props.onClose();
   }
 
   function handleReset() {

--- a/src/components/FilterTopGrower.js
+++ b/src/components/FilterTopGrower.js
@@ -73,6 +73,7 @@ function FilterTopGrower(props) {
       deviceIdentifier,
     });
     props.onSubmit && props.onSubmit(filter);
+    props.onClick && props.onClick();
   }
 
   const handleReset = () => {

--- a/src/components/GrowerFilterHeader.js
+++ b/src/components/GrowerFilterHeader.js
@@ -50,14 +50,14 @@ function GrowersFilterHeader(props) {
           </Button>,
         ]}
       >
-        {isFilterShown && (
+        <div style={{ display: isFilterShown ? 'block' : 'none' }}>
           <FilterTopGrower
             isOpen={isFilterShown}
             onSubmit={handleFilterSubmit}
             filter={growerContext.filter}
             onClick={handleFilterClick}
           />
-        )}
+        </div>
       </Navbar>
     </Grid>
   );

--- a/src/components/Verify.js
+++ b/src/components/Verify.js
@@ -586,7 +586,7 @@ const Verify = (props) => {
                 </Button>,
               ]}
             >
-              {isFilterShown && (
+              <div style={{ display: isFilterShown ? 'block' : 'none' }}>
                 <FilterTop
                   isOpen={isFilterShown}
                   onSubmit={(filter) => {
@@ -595,7 +595,7 @@ const Verify = (props) => {
                   filter={verifyContext.filter}
                   onClose={handleFilterClick}
                 />
-              )}
+              </div>
             </Navbar>
           </Grid>
           <Grid


### PR DESCRIPTION
## Description

- Preserved filter form values when the filter panel is collapsed and reopened.

- Updated Verify, Captures, and Growers filters to stay mounted while hidden.

- Kept existing Apply behavior by collapsing the filter after submission.

- Kept Reset behavior unchanged so filter values are only cleared when Reset is clicked.

**Issue(s) addressed**

- Prevent filter settings from resetting when the filter panel is collapsed.

- Preserve in-progress filter values on Verify, Captures, and Growers pages.

- Allow users to reopen the filter and see the same values that produced the visible results.

- Resolves #1018

**What kind of change(s) does this PR introduce?**

- [x] Bug fix

## Issue

- Current behaviour: Collapsing the filter panel unmounts the filter component, causing the current filter values to reset when the panel is opened again.

- New behaviour: The filter panel is hidden without unmounting the filter component, so values remain unchanged when collapsed and reopened. Filter values are only reset when the Reset button is clicked or when the user leaves or refreshes the page.

## Breaking change

No

## Screenshots:
Initially user enters filter values:

<img width="1680" height="969" alt="Screenshot 2026-07-07 at 9 01 06 PM" src="https://github.com/user-attachments/assets/8629f513-16b7-4b9d-adf6-7e2efb3b052d" />

After user clicks "Apply" filter (filter component collapses):

<img width="1680" height="969" alt="Screenshot 2026-07-07 at 9 02 09 PM" src="https://github.com/user-attachments/assets/e149e174-5313-4ee7-bca7-b8bc31f20c50" />

After user reopens the filter component (values remain):

<img width="1680" height="969" alt="Screenshot 2026-07-07 at 9 02 59 PM" src="https://github.com/user-attachments/assets/d2f22751-2190-4df5-9158-8baa95a376e2" />
