### PR TITLE
fix(growers): resolve org not set filter not applying in grower module

### DIFF
--- a/src/components/EditGrower.js
+++ b/src/components/EditGrower.js
@@ -178,7 +178,10 @@ const EditGrower = (props) => {
               },
             ]}
             handleSelection={(org) => {
-              handleChange('organizationId', org?.id || null);
+              handleChange(
+                'organizationId',
+                org?.id === ORGANIZATION_NOT_SET ? null : org?.id || null
+              );
             }}
           />
         </Grid>

--- a/src/components/common/SelectOrg.js
+++ b/src/components/common/SelectOrg.js
@@ -36,7 +36,7 @@ function SelectOrg({ orgId, defaultOrgs, handleSelection }) {
 
   const handleChange = (e) => {
     e.preventDefault();
-    const org = orgList.find(
+    const org = [...defaultOrgList, ...orgList].find(
       (o) => o.id === e.target.value || o.stakeholder_uuid === e.target.value
     );
     // console.log('handleChange', e);


### PR DESCRIPTION
## Description

- Fixes an issue where selecting "Not set" in the Organization filter on the Growers page had no effect. It returned the same results as "All".
- In `SelectOrg.js`, `handleChange` only searched `orgList` which only includes real orgs loaded from the API when looking up the selected org object. "Not set" is a hardcoded option in `defaultOrgList`, not a real org, so it was never found. This caused `handleSelection` to be called with the raw string `'ORGANIZATION_NOT_SET'` instead of the object. The filter callback in `FilterTopGrower.js` tried to read `.id` off that string, got `undefined`, and the filter was lost before it reached the API.
- Fixed by searching both `defaultOrgList` and `orgList` in `SelectOrg.js` so "Not set" is correctly resolved to its object and passed through the filter chain, resulting in `organizationId: null` in the API call.
- Updated `EditGrower.js` to explicitly convert `ORGANIZATION_NOT_SET` to `null` when saving, preserving the correct behaviour of unsetting a grower's organization via the edit.

**Issue(s) addressed**

- Resolves #1044

**What kind of change(s) does this PR introduce?**

- [x] Bug fix

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**

Selecting "Not set" in the Organization filter on the Growers page sends an API call identical to "All". `organizationId` is absent from the where clause, so all growers are returned regardless of whether they have an org assigned.

<img width="1919" height="870" alt="bug1" src="https://github.com/user-attachments/assets/e3ff4e2e-4c5a-4230-bc66-001ad9156ed9" /><br>

Editing a grower and setting their organization to "Not set" incorrectly sent the string `'ORGANIZATION_NOT_SET'` to the API instead of `null`, which would fail to unset the org.

<img width="1919" height="868" alt="bug2" src="https://github.com/user-attachments/assets/eabb94a9-0260-4838-a048-95fccf51f59e" /><br>


**What is the new behavior?**

Selecting "Not set" in the filter sends `"organizationId": null` in the API where clause, returning only growers with no organization assigned.

<img width="1919" height="869" alt="fix1" src="https://github.com/user-attachments/assets/8d6ad523-dcb5-4c91-8b53-f13da4da4702" /><br>


Editing a grower and setting their organization to "Not set" now correctly sends `organizationId: null` to the API, unsetting the org as expected.

<img width="1919" height="875" alt="fix2" src="https://github.com/user-attachments/assets/be6da7cd-6217-4b68-a66a-13c221cfe8d0" /><br>


## Breaking change

**Does this PR introduce a breaking change?**

No.

## Other useful information

Root cause: `SelectOrg.js` searched only `orgList` (API-loaded orgs) in `handleChange`, missing the hardcoded "Not set" entry in `defaultOrgList`. When not found, the fallback passed the raw string `'ORGANIZATION_NOT_SET'` to the callback. Callers expecting an object called `.id` on a string got `undefined`, which is dropped by `JSON.stringify`, leaving no org filter in the API call.

The `EditGrower.js` fix is required because that component needs `null` sent directly to the API to unset an org, whereas filter components use `'ORGANIZATION_NOT_SET'` as a sentinel for the filter model.
