### PR TITLE
fix(verify): restrict verify tool access to approve_tree and super_pe…

### DIFF
--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -63,7 +63,6 @@ function getRoutes(user) {
       icon: IconThumbsUpDown,
       disabled: !hasPermission(user, [
         POLICIES.SUPER_PERMISSION,
-        POLICIES.LIST_TREE,
         POLICIES.APPROVE_TREE,
       ]),
     },


### PR DESCRIPTION
## Description

- Fixes an issue where users with only the `list_tree` policy could access the Verify tool.
- In `AppContext.js`, the `hasPermission` check for the Verify route included `POLICIES.LIST_TREE` alongside `POLICIES.SUPER_PERMISSION` and `POLICIES.APPROVE_TREE`. Since `hasPermission` returns `true` if the user has at least one of the listed policies, `list_tree` alone was sufficient to gain access.
- Removed `POLICIES.LIST_TREE` from the Verify route permission check so only users with `approve_tree` or `super_permission` can access the tool.

**Issue(s) addressed**

- Resolves #818

**What kind of change(s) does this PR introduce?**

- [x] Bug fix

**Please check if the PR fulfils these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**

Users with only the `list_tree` policy can access the Verify tool. The Verify tool should be restricted to users with `approve_tree` or `super_permission` policies only.

**What is the new behavior?**

Only users with `approve_tree` or `super_permission` policies can access the Verify tool. Users with only `list_tree` are shown the Unauthorized page.

## Breaking change

**Does this PR introduce a breaking change?**

No.

## Other useful information