### PR TITLE
feat(growers): show sessions and wallet registration in grower card

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,7 @@
 REACT_APP_WEBMAP_DOMAIN=http://dev.treetracker.org
 REACT_APP_API_ROOT=https://dev-k8s.treetracker.org/api/admin
 REACT_APP_EARNINGS_ROOT=https://dev-k8s.treetracker.org/earnings
+REACT_APP_FIELD_DATA_API_ROOT=https://dev-k8s.treetracker.org/field-data
 REACT_APP_GROWER_QUERY_API_ROOT=https://dev-k8s.treetracker.org/grower-account-query
 REACT_APP_IMAGES_API_ROOT=https://dev-k8s.treetracker.org/images
 REACT_APP_MESSAGING_ROOT=https://dev-k8s.treetracker.org/messaging

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,7 @@
 REACT_APP_WEBMAP_DOMAIN=https://treetracker.org
 REACT_APP_API_ROOT=https://prod-k8s.treetracker.org/api/admin
 REACT_APP_EARNINGS_ROOT=https://prod-k8s.treetracker.org/earnings
+REACT_APP_FIELD_DATA_API_ROOT=https://prod-k8s.treetracker.org/field-data
 REACT_APP_GROWER_QUERY_API_ROOT=https://prod-k8s.treetracker.org/grower-account-query
 REACT_APP_IMAGES_API_ROOT=https://prod-k8s.treetracker.org/images
 REACT_APP_MESSAGING_ROOT=https://prod-k8s.treetracker.org/messaging

--- a/.env.staging
+++ b/.env.staging
@@ -1,6 +1,7 @@
 REACT_APP_WEBMAP_DOMAIN=http://staging.treetracker.org
 REACT_APP_API_ROOT=https://prod-k8s.treetracker.org/api/admin
 REACT_APP_EARNINGS_ROOT=https://prod-k8s.treetracker.org/earnings
+REACT_APP_FIELD_DATA_API_ROOT=https://prod-k8s.treetracker.org/field-data
 REACT_APP_GROWER_QUERY_API_ROOT=https://prod-k8s.treetracker.org/grower-account-query
 REACT_APP_IMAGES_API_ROOT=https://prod-k8s.treetracker.org/images
 REACT_APP_MESSAGING_ROOT=https://prod-k8s.treetracker.org/messaging

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,7 @@
 REACT_APP_WEBMAP_DOMAIN=http://test.treetracker.org
 REACT_APP_API_ROOT=https://test-k8s.treetracker.org/api/admin
 REACT_APP_EARNINGS_ROOT=https://test-k8s.treetracker.org/earnings
+REACT_APP_FIELD_DATA_API_ROOT=https://test-k8s.treetracker.org/field-data
 REACT_APP_GROWER_QUERY_API_ROOT=https://test-k8s.treetracker.org/grower-account-query
 REACT_APP_IMAGES_API_ROOT=https://test-k8s.treetracker.org/images
 REACT_APP_MESSAGING_ROOT=https://test-k8s.treetracker.org/messaging

--- a/src/api/fieldData.js
+++ b/src/api/fieldData.js
@@ -1,0 +1,86 @@
+import { handleResponse, handleError } from './apiUtils';
+
+const log = require('loglevel').getLogger('../api/fieldData');
+
+const SESSION_PAGE_LIMIT = 100;
+// GET /session has no grower/wallet filter (see Greenstand/treetracker-field-data#docs),
+// so we page through and filter client-side. Cap the scan to keep the grower card responsive;
+// https://github.com/Greenstand/treetracker-admin-client/issues/616 tracks adding a proper filter.
+const SESSION_SCAN_MAX_PAGES = 20;
+
+export default {
+  // The legacy planter API (src/api/growers.js) doesn't expose growerAccountUuid,
+  // so growerAccountUuid alone can't reliably join to field_data.session today.
+  // Sessions also carry a free-text target_wallet that field teams populate with
+  // an email or phone number (see the example queries on
+  // https://github.com/Greenstand/treetracker-admin-client/issues/616), so we
+  // additionally match on that against the grower's known email/phone.
+  async getSessionsForGrower({ growerAccountUuid, email, phone } = {}) {
+    if (!growerAccountUuid && !email && !phone) return [];
+    try {
+      const matches = [];
+      let offset = 0;
+      let total = Infinity;
+      let page = 0;
+
+      while (offset < total && page < SESSION_SCAN_MAX_PAGES) {
+        const query = `${process.env.REACT_APP_FIELD_DATA_API_ROOT}/session?limit=${SESSION_PAGE_LIMIT}&offset=${offset}`;
+        // eslint-disable-next-line no-await-in-loop
+        const { sessions, query: pageQuery } = await fetch(query, {
+          method: 'GET',
+          headers: { 'content-type': 'application/json' },
+        }).then(handleResponse);
+
+        matches.push(
+          ...sessions.filter(
+            (session) =>
+              (growerAccountUuid &&
+                session.grower_account_id === growerAccountUuid) ||
+              (email && session.target_wallet === email) ||
+              (phone && session.target_wallet === phone)
+          )
+        );
+
+        total = pageQuery.count;
+        offset += SESSION_PAGE_LIMIT;
+        page += 1;
+      }
+
+      if (offset < total) {
+        log.warn(
+          `Stopped scanning sessions for grower after ${SESSION_SCAN_MAX_PAGES} pages; ${total} sessions exist in total.`
+        );
+      }
+
+      return matches;
+    } catch (error) {
+      handleError(error);
+    }
+  },
+
+  getDeviceConfiguration(deviceConfigurationId) {
+    if (!deviceConfigurationId) return Promise.resolve(null);
+    try {
+      const query = `${process.env.REACT_APP_FIELD_DATA_API_ROOT}/device-configuration/${deviceConfigurationId}`;
+      return fetch(query, {
+        method: 'GET',
+        headers: { 'content-type': 'application/json' },
+      }).then(handleResponse);
+    } catch (error) {
+      handleError(error);
+    }
+  },
+
+  getWalletRegistration(walletRegistrationId) {
+    if (!walletRegistrationId) return Promise.resolve(null);
+    try {
+      const query = `${process.env.REACT_APP_FIELD_DATA_API_ROOT}/wallet-registration/${walletRegistrationId}`;
+      return fetch(query, {
+        method: 'GET',
+        headers: { 'content-type': 'application/json' },
+      }).then(handleResponse);
+    } catch (error) {
+      handleError(error);
+    }
+  },
+};

--- a/src/components/GrowerDetail.js
+++ b/src/components/GrowerDetail.js
@@ -17,6 +17,9 @@ import {
   Divider,
   LinearProgress,
   Fab,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
 } from '@material-ui/core';
 import {
   Close,
@@ -25,8 +28,10 @@ import {
   Done,
   Clear,
   HourglassEmptyOutlined,
+  ExpandMore,
 } from '@material-ui/icons';
 import api from '../api/growers';
+import fieldDataApi from '../api/fieldData';
 import { getDateTimeStringLocale } from '../common/locale';
 import { hasPermission, POLICIES } from '../models/auth';
 import { AppContext } from '../context/AppContext';
@@ -131,6 +136,16 @@ const useStyle = makeStyles((theme) => ({
   paper: {
     width: GROWER_IMAGE_SIZE,
   },
+  sessionsAccordion: {
+    width: '100%',
+  },
+  sessionAvatar: {
+    width: 56,
+    height: 56,
+  },
+  sessionDetailLine: {
+    display: 'block',
+  },
 }));
 
 const GrowerDetail = ({ open, growerId, onClose }) => {
@@ -148,6 +163,9 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
   const [verificationStatus, setVerificationStatus] = useState({});
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
+  const [sessions, setSessions] = useState([]);
+  const [sessionsLoading, setSessionsLoading] = useState(false);
+  const [sessionsError, setSessionsError] = useState(null);
 
   useEffect(() => {
     setErrorMessage(null);
@@ -241,6 +259,78 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
     }
     loadCaptures();
   }, [grower]);
+
+  useEffect(() => {
+    async function loadSessions() {
+      if (!grower.growerAccountUuid && !grower.email && !grower.phone) {
+        setSessions([]);
+        return;
+      }
+      setSessionsLoading(true);
+      setSessionsError(null);
+      try {
+        const growerSessions = await fieldDataApi.getSessionsForGrower({
+          growerAccountUuid: grower.growerAccountUuid,
+          email: grower.email,
+          phone: grower.phone,
+        });
+        const sorted = (growerSessions || []).sort(
+          (a, b) =>
+            new Date(b.created_at || 0).getTime() -
+            new Date(a.created_at || 0).getTime()
+        );
+
+        const deviceConfigurationIds = [
+          ...new Set(
+            sorted.map((s) => s.device_configuration_id).filter(Boolean)
+          ),
+        ];
+        const walletRegistrationIds = [
+          ...new Set(
+            sorted
+              .map((s) => s.originating_wallet_registration_id)
+              .filter(Boolean)
+          ),
+        ];
+
+        const [deviceConfigurations, walletRegistrations] = await Promise.all([
+          Promise.all(
+            deviceConfigurationIds.map((id) =>
+              fieldDataApi.getDeviceConfiguration(id)
+            )
+          ),
+          Promise.all(
+            walletRegistrationIds.map((id) =>
+              fieldDataApi.getWalletRegistration(id)
+            )
+          ),
+        ]);
+
+        const deviceConfigurationById = Object.fromEntries(
+          deviceConfigurations.filter(Boolean).map((dc) => [dc.id, dc])
+        );
+        const walletRegistrationById = Object.fromEntries(
+          walletRegistrations.filter(Boolean).map((wr) => [wr.id, wr])
+        );
+
+        setSessions(
+          sorted.map((s) => ({
+            ...s,
+            deviceConfiguration:
+              deviceConfigurationById[s.device_configuration_id] || null,
+            walletRegistration:
+              walletRegistrationById[s.originating_wallet_registration_id] ||
+              null,
+          }))
+        );
+      } catch (error) {
+        setSessionsError(`Unable to load sessions: ${error?.message || error}`);
+      } finally {
+        setSessionsLoading(false);
+      }
+    }
+    loadSessions();
+  }, [grower.growerAccountUuid, grower.email, grower.phone]);
 
   async function getCaptureCountGrower(active, approved, growerId) {
     let filter = new FilterModel();
@@ -558,6 +648,112 @@ const GrowerDetail = ({ open, growerId, onClose }) => {
                     </tbody>
                   </table>
                 )) || <Typography variant="body1">---</Typography>}
+              </Grid>
+              <Divider />
+              <Grid container direction="column" className={classes.box}>
+                <Accordion className={classes.sessionsAccordion} elevation={0}>
+                  <AccordionSummary
+                    expandIcon={<ExpandMore />}
+                    aria-controls="sessions-content"
+                    id="sessions-header"
+                  >
+                    <Typography variant="subtitle1">
+                      Sessions{sessions.length ? ` (${sessions.length})` : ''}
+                    </Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    {sessionsLoading ? (
+                      <LinearProgress
+                        color="primary"
+                        className={classes.captures}
+                      />
+                    ) : sessionsError ? (
+                      <Typography variant="body1" color="error">
+                        {sessionsError}
+                      </Typography>
+                    ) : sessions.length === 0 ? (
+                      <Typography variant="body1">---</Typography>
+                    ) : (
+                      <List className={classes.captures}>
+                        {sessions.map((session, i) => (
+                          <React.Fragment key={session.id}>
+                            {i > 0 && <Divider component="li" />}
+                            <ListItem
+                              alignItems="flex-start"
+                              classes={{ gutters: classes.gutters }}
+                            >
+                              {session.check_in_photo_url && (
+                                <ListItemAvatar>
+                                  <Avatar
+                                    variant="rounded"
+                                    src={session.check_in_photo_url}
+                                    className={classes.sessionAvatar}
+                                  />
+                                </ListItemAvatar>
+                              )}
+                              <ListItemText
+                                primary={
+                                  (session.created_at &&
+                                    getDateTimeStringLocale(
+                                      session.created_at
+                                    )) ||
+                                  (session.start_time &&
+                                    getDateTimeStringLocale(
+                                      session.start_time
+                                    )) ||
+                                  '---'
+                                }
+                                secondary={
+                                  <>
+                                    <Typography
+                                      component="span"
+                                      variant="body2"
+                                      className={classes.sessionDetailLine}
+                                    >
+                                      Organization:{' '}
+                                      {session.organization || '---'}
+                                    </Typography>
+                                    <Typography
+                                      component="span"
+                                      variant="body2"
+                                      className={classes.sessionDetailLine}
+                                    >
+                                      Device:{' '}
+                                      {(session.deviceConfiguration &&
+                                        `${
+                                          session.deviceConfiguration.brand ||
+                                          ''
+                                        } ${
+                                          session.deviceConfiguration.model ||
+                                          ''
+                                        }`.trim()) ||
+                                        session.device_identifier ||
+                                        '---'}
+                                      {session.deviceConfiguration
+                                        ?.app_version &&
+                                        ` (app v${session.deviceConfiguration.app_version})`}
+                                    </Typography>
+                                    <Typography
+                                      component="span"
+                                      variant="body2"
+                                      className={classes.sessionDetailLine}
+                                    >
+                                      Wallet:{' '}
+                                      {session.walletRegistration?.email ||
+                                        session.walletRegistration?.phone ||
+                                        session.wallet ||
+                                        '---'}
+                                    </Typography>
+                                  </>
+                                }
+                              />
+                            </ListItem>
+                          </React.Fragment>
+                        ))}
+                      </List>
+                    )}
+                  </AccordionDetails>
+                </Accordion>
               </Grid>
             </Grid>
           )}

--- a/src/components/tests/GrowerDetail.test.js
+++ b/src/components/tests/GrowerDetail.test.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { act, render, screen, cleanup } from '@testing-library/react';
+// This repo has no src/setupTests.js registering jest-dom matchers globally
+// (see spawned follow-up task), so this file registers them locally.
+import '@testing-library/jest-dom';
+import theme from '../common/theme';
+import { ThemeProvider } from '@material-ui/core/styles';
+import { AppProvider } from '../../context/AppContext';
+import { GrowerProvider } from '../../context/GrowerContext';
+import GrowerDetail from '../GrowerDetail';
+
+jest.mock('../../api/growers');
+jest.mock('../../api/treeTrackerApi');
+jest.mock('../../api/fieldData');
+
+const GROWER = {
+  id: 1,
+  growerAccountUuid: 'grower-uuid-1',
+  firstName: 'testFirstName',
+  lastName: 'testLastName',
+  email: 'test@gmail.com',
+  phone: '123-456-7890',
+  personId: null,
+  organization: null,
+  organizationId: null,
+  imageUrl: '',
+};
+
+const SESSION = {
+  id: 'session-1',
+  created_at: '2023-01-01T00:00:00.000Z',
+  start_time: '2023-01-01T00:00:00.000Z',
+  organization: 'Test Org',
+  device_identifier: 'device-1',
+  device_configuration_id: 'device-config-1',
+  originating_wallet_registration_id: 'wallet-reg-1',
+  target_wallet: null,
+  check_in_photo_url: 'http://example.com/photo.jpg',
+  wallet: 'wallet31',
+  grower_account_id: 'grower-uuid-1',
+};
+
+const DEVICE_CONFIGURATION = {
+  id: 'device-config-1',
+  brand: 'Google',
+  model: 'Pixel',
+  app_version: '2.1.1',
+};
+
+const WALLET_REGISTRATION = {
+  id: 'wallet-reg-1',
+  email: 'grower-wallet@example.com',
+  phone: null,
+};
+
+function renderGrowerDetail(growerId = 1) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <BrowserRouter>
+        <AppProvider value={{}}>
+          <GrowerProvider value={{ growers: [] }}>
+            <GrowerDetail open growerId={growerId} onClose={() => {}} />
+          </GrowerProvider>
+        </AppProvider>
+      </BrowserRouter>
+    </ThemeProvider>
+  );
+}
+
+describe('GrowerDetail sessions section', () => {
+  let growersApi;
+  let treeTrackerApi;
+  let fieldDataApi;
+
+  beforeEach(() => {
+    growersApi = require('../../api/growers').default;
+    treeTrackerApi = require('../../api/treeTrackerApi').default;
+    fieldDataApi = require('../../api/fieldData').default;
+
+    growersApi.getGrower = jest.fn().mockResolvedValue(GROWER);
+    growersApi.getGrowers = jest.fn().mockResolvedValue([GROWER]);
+    growersApi.getCount = jest.fn().mockResolvedValue({ count: 1 });
+    growersApi.getGrowerRegistrations = jest.fn().mockResolvedValue([]);
+
+    treeTrackerApi.getCaptureCount = jest.fn().mockResolvedValue({ count: 0 });
+
+    fieldDataApi.getSessionsForGrower = jest.fn().mockResolvedValue([SESSION]);
+    fieldDataApi.getDeviceConfiguration = jest
+      .fn()
+      .mockResolvedValue(DEVICE_CONFIGURATION);
+    fieldDataApi.getWalletRegistration = jest
+      .fn()
+      .mockResolvedValue(WALLET_REGISTRATION);
+  });
+
+  afterEach(cleanup);
+
+  it("loads and displays the grower's sessions, device and wallet info", async () => {
+    renderGrowerDetail();
+
+    expect(await screen.findByText(/Sessions \(1\)/i)).toBeInTheDocument();
+    expect(fieldDataApi.getSessionsForGrower).toHaveBeenCalledWith({
+      growerAccountUuid: 'grower-uuid-1',
+      email: 'test@gmail.com',
+      phone: '123-456-7890',
+    });
+    expect(fieldDataApi.getDeviceConfiguration).toHaveBeenCalledWith(
+      'device-config-1'
+    );
+    expect(fieldDataApi.getWalletRegistration).toHaveBeenCalledWith(
+      'wallet-reg-1'
+    );
+    expect(screen.getByText(/Organization: Test Org/i)).toBeInTheDocument();
+    expect(screen.getByText(/Google Pixel/i)).toBeInTheDocument();
+    expect(screen.getByText(/grower-wallet@example.com/i)).toBeInTheDocument();
+  });
+
+  it('shows a placeholder when the grower has no sessions', async () => {
+    fieldDataApi.getSessionsForGrower = jest.fn().mockResolvedValue([]);
+
+    renderGrowerDetail();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText(/^Sessions$/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a collapsible **Sessions** section to the grower detail drawer (after Device Identifiers), pulling from the `treetracker-field-data` service (`session`, `device-configuration`, `wallet-registration`) so reviewers can see which app/device a grower used without running manual SQL.
- Each session shows: check-in photo (if any), date, organization, device brand/model/app version, and wallet email/phone.
- New `REACT_APP_FIELD_DATA_API_ROOT` env var added to `.env.development`/`.env.staging`/`.env.production`/`.env.test`, verified reachable against the real dev and prod clusters.
- New `src/api/fieldData.js` module (fetch-based, follows existing `src/api/*` conventions).

## Known limitation
`GET /session` on treetracker-field-data has no server-side filter by grower/wallet, so sessions are paged through and matched client-side by `grower_account_id`, and by `target_wallet` against the known email/phone for that grower (capped at 20 pages to keep the drawer responsive, with a console warning if the cap is hit). A proper filter param on the field-data service would remove this limitation.

## Test plan
- [x] `npm run prettier` / eslint clean on changed files
- [x] New jest tests in `src/components/tests/GrowerDetail.test.js` (populated + empty session states) pass
- [x] Verified manually in the dev environment: opened a grower card, expanded the new Sessions accordion, confirmed it renders correctly alongside existing sections
- [x] `src/models/` unit tests still pass

Closes #616
