### PR TITLE
feat(verify): add verification dashboard landing view (phase1)

### DIFF
--- a/src/components/VerificationDashboard/UnverifiedCapturesPanel.js
+++ b/src/components/VerificationDashboard/UnverifiedCapturesPanel.js
@@ -1,0 +1,140 @@
+import React from 'react';
+import { formatDistanceToNow } from 'date-fns';
+
+import Paper from '@material-ui/core/Paper';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { makeStyles } from '@material-ui/core/styles';
+
+import OptimizedImage from '../OptimizedImage';
+import { useRecentUnverifiedCaptures, RECENT_CAPTURE_COUNT } from './data';
+
+const THUMBNAIL_SIZE = 46;
+
+const usePanelStyles = makeStyles((theme) => ({
+  panel: {
+    padding: theme.spacing(6),
+    borderRadius: '10px',
+    height: '100%',
+    boxSizing: 'border-box',
+  },
+  panelHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+    gap: theme.spacing(3),
+    flexWrap: 'wrap',
+    paddingBlockEnd: theme.spacing(3),
+  },
+  panelSub: {
+    color: theme.palette.stats.carbonGrey,
+  },
+  emptyState: {
+    color: theme.palette.stats.carbonGrey,
+    paddingBlock: theme.spacing(4),
+  },
+  captureRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(3),
+    padding: `${theme.spacing(3)}px 0`,
+    borderBottom: `1px solid ${theme.palette.stats.lavenderPinocchio}`,
+    '&:last-child': {
+      borderBottom: 'none',
+    },
+  },
+  captureThumb: {
+    position: 'relative',
+    width: THUMBNAIL_SIZE,
+    height: THUMBNAIL_SIZE,
+    flex: 'none',
+    borderRadius: '6px',
+    overflow: 'hidden',
+    backgroundColor: theme.palette.stats.lavenderPinocchio,
+  },
+  captureMeta: {
+    minWidth: 0,
+    flex: 1,
+  },
+  captureId: {
+    fontWeight: 700,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  captureSub: {
+    color: theme.palette.stats.carbonGrey,
+  },
+  captureWhen: {
+    color: theme.palette.stats.carbonGrey,
+    whiteSpace: 'nowrap',
+  },
+}));
+
+function UnverifiedCapturesPanel() {
+  const classes = usePanelStyles();
+
+  const { data: captures, isLoading, isError } = useRecentUnverifiedCaptures();
+
+  return (
+    <Paper elevation={3} className={classes.panel}>
+      <Box className={classes.panelHeader}>
+        <Typography variant="h6">Unverified captures</Typography>
+        <Typography variant="body2" className={classes.panelSub}>
+          Recent {RECENT_CAPTURE_COUNT} captures
+        </Typography>
+      </Box>
+
+      {isLoading && <CircularProgress size={'32px'} />}
+
+      {isError && (
+        <Typography variant="body1" className={classes.emptyState}>
+          Could not load unverified captures. Try again later.
+        </Typography>
+      )}
+
+      {!isLoading && !isError && captures?.length === 0 && (
+        <Typography variant="body1" className={classes.emptyState}>
+          Nothing is waiting to be verified.
+        </Typography>
+      )}
+
+      {!isLoading &&
+        !isError &&
+        captures?.map((capture) => (
+          <Box key={capture.id} className={classes.captureRow}>
+            <div className={classes.captureThumb}>
+              <OptimizedImage
+                src={capture.imageUrl}
+                width={THUMBNAIL_SIZE}
+                height={THUMBNAIL_SIZE}
+                fixed
+                alertHeight={THUMBNAIL_SIZE}
+                alertWidth={THUMBNAIL_SIZE}
+              />
+            </div>
+            <div className={classes.captureMeta}>
+              <Typography variant="body1" className={classes.captureId}>
+                {capture.uuid || capture.id}
+              </Typography>
+              {capture.planterIdentifier && (
+                <Typography variant="body2" className={classes.captureSub}>
+                  {capture.planterIdentifier}
+                </Typography>
+              )}
+            </div>
+            {capture.timeCreated && (
+              <Typography variant="body2" className={classes.captureWhen}>
+                {formatDistanceToNow(new Date(capture.timeCreated), {
+                  addSuffix: true,
+                })}
+              </Typography>
+            )}
+          </Box>
+        ))}
+    </Paper>
+  );
+}
+
+export default UnverifiedCapturesPanel;

--- a/src/components/VerificationDashboard/VerificationDashboard.js
+++ b/src/components/VerificationDashboard/VerificationDashboard.js
@@ -1,0 +1,102 @@
+import React, { useContext } from 'react';
+import { Link } from 'react-router-dom';
+
+import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+import { withStyles } from '@material-ui/core/styles';
+
+import NatureOutlinedIcon from '@material-ui/icons/NatureOutlined';
+import AccessTimeOutlinedIcon from '@material-ui/icons/AccessTimeOutlined';
+
+import styles from './VerificationDashboard.styles';
+import Menu from '../common/Menu';
+import theme from '../common/theme';
+import DashStat from '../DashStat';
+import UnverifiedCapturesPanel from './UnverifiedCapturesPanel';
+import { usePendingCaptureCount, useOldestWaiting } from './data';
+import { AppContext } from '../../context/AppContext';
+import { hasPermission, POLICIES } from '../../models/auth';
+
+function DashStatCapturesPending() {
+  const { data, isError } = usePendingCaptureCount();
+
+  return (
+    <DashStat
+      label="Captures Pending"
+      data={isError ? '—' : data}
+      color={theme.palette.stats.red}
+      Icon={NatureOutlinedIcon}
+    />
+  );
+}
+
+function DashStatOldestWaiting() {
+  const { data, isError } = useOldestWaiting();
+
+  return (
+    <DashStat
+      label="Oldest Waiting"
+      data={isError ? '—' : data}
+      color={theme.palette.stats.orange}
+      Icon={AccessTimeOutlinedIcon}
+    />
+  );
+}
+
+function VerificationDashboard(props) {
+  const { classes } = props;
+  const appContext = useContext(AppContext);
+
+  const canListCaptures = hasPermission(appContext.user, [
+    POLICIES.SUPER_PERMISSION,
+    POLICIES.LIST_TREE,
+    POLICIES.APPROVE_TREE,
+  ]);
+
+  return (
+    <Grid className={classes.box}>
+      <Grid className={classes.menuAside}>
+        <Paper elevation={3} className={classes.menu}>
+          <Menu variant="plain" />
+        </Paper>
+      </Grid>
+      <Grid className={classes.rightBox}>
+        <Grid container className={classes.header}>
+          <Grid item>
+            <Typography variant="h5">Verification Dashboard</Typography>
+            <Typography variant="body1" className={classes.subtitle}>
+              Captures awaiting verification
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Button
+              color="primary"
+              variant="contained"
+              component={Link}
+              to="/verify/captures"
+            >
+              View all unverified captures
+            </Button>
+          </Grid>
+        </Grid>
+
+        {canListCaptures && (
+          <React.Fragment>
+            <div className={classes.dashstatWraper}>
+              <DashStatCapturesPending />
+              <DashStatOldestWaiting />
+            </div>
+
+            <div className={classes.split}>
+              <UnverifiedCapturesPanel />
+            </div>
+          </React.Fragment>
+        )}
+      </Grid>
+    </Grid>
+  );
+}
+
+export default withStyles(styles)(VerificationDashboard);

--- a/src/components/VerificationDashboard/VerificationDashboard.styles.js
+++ b/src/components/VerificationDashboard/VerificationDashboard.styles.js
@@ -1,0 +1,57 @@
+import { MENU_WIDTH } from '../common/Menu';
+
+const styles = (theme) => ({
+  box: {
+    width: '100%',
+    height: '100%',
+    position: 'relative',
+  },
+  menuAside: {
+    height: '100%',
+    position: 'absolute',
+    left: 0,
+    top: 0,
+  },
+  menu: {
+    height: '100%',
+    overflow: 'hidden',
+  },
+  rightBox: {
+    height: '100%',
+    position: 'absolute',
+    padding: '40px',
+    left: MENU_WIDTH,
+    top: 0,
+    right: 0,
+    backgroundColor: 'rgb(239, 239, 239)',
+    boxSizing: 'border-box',
+    overflowY: 'auto',
+  },
+  header: {
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingBlockEnd: theme.spacing(6),
+    gap: theme.spacing(4),
+  },
+  subtitle: {
+    color: theme.palette.stats.carbonGrey,
+  },
+  dashstatWraper: {
+    display: 'flex',
+    flexDirection: 'row',
+    gap: '20px',
+    flexWrap: 'wrap',
+  },
+  split: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1.7fr) minmax(0, 1fr)',
+    gap: theme.spacing(4),
+    alignItems: 'stretch',
+    marginBlockStart: theme.spacing(8),
+    '@media (max-width: 1080px)': {
+      gridTemplateColumns: 'minmax(0, 1fr)',
+    },
+  },
+});
+
+export default styles;

--- a/src/components/VerificationDashboard/data.js
+++ b/src/components/VerificationDashboard/data.js
@@ -1,0 +1,69 @@
+import { useQuery } from '@tanstack/react-query';
+import { differenceInCalendarDays } from 'date-fns';
+
+import { countToLocaleString } from '../../common/numbers';
+import captureApi from '../../api/treeTrackerApi';
+import FilterModel from '../../models/Filter';
+
+export const RECENT_CAPTURE_COUNT = 5;
+
+const QUERY_OPTIONS = {
+  staleTime: 1000 * 60 * 5,
+  refetchOnWindowFocus: false,
+};
+
+function pendingFilter() {
+  return new FilterModel({ approved: false, active: true });
+}
+
+export function usePendingCaptureCount() {
+  return useQuery({
+    ...QUERY_OPTIONS,
+    queryKey: ['captureCount', 'pending'],
+    queryFn: () => captureApi.getCaptureCount(pendingFilter()),
+    select: (result) => {
+      const count = Number(result?.count);
+      return Number.isFinite(count) ? countToLocaleString(count) || '0' : '—';
+    },
+  });
+}
+
+export function useOldestWaiting() {
+  return useQuery({
+    ...QUERY_OPTIONS,
+    queryKey: ['oldestUnverifiedCapture'],
+    queryFn: () =>
+      captureApi.getCaptureImages({
+        skip: 0,
+        rowsPerPage: 1,
+        orderBy: 'timeCreated',
+        order: 'asc',
+        filter: pendingFilter(),
+      }),
+    select: (captures) => {
+      const oldest = captures?.[0];
+      if (!oldest?.timeCreated) return '—';
+      const days = differenceInCalendarDays(
+        new Date(),
+        new Date(oldest.timeCreated)
+      );
+      if (days < 1) return 'Today';
+      return `${days} ${days === 1 ? 'day' : 'days'}`;
+    },
+  });
+}
+
+export function useRecentUnverifiedCaptures() {
+  return useQuery({
+    ...QUERY_OPTIONS,
+    queryKey: ['recentPendingCaptures'],
+    queryFn: () =>
+      captureApi.getCaptureImages({
+        skip: 0,
+        rowsPerPage: RECENT_CAPTURE_COUNT,
+        orderBy: 'timeCreated',
+        order: 'desc',
+        filter: pendingFilter(),
+      }),
+  });
+}

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -3,6 +3,7 @@ import isEqual from 'react-fast-compare';
 import axios from 'axios';
 
 import VerifyView from '../views/VerifyView';
+import VerificationDashboardView from '../views/VerificationDashboardView';
 import GrowersView from '../views/GrowersView';
 import CapturesView from '../views/CapturesView';
 import EarningsView from '../views/EarningsView/EarningsView';
@@ -28,6 +29,7 @@ import AccountBalanceIcon from '@material-ui/icons/AccountBalance';
 import IconPermIdentity from '@material-ui/icons/PermIdentity';
 import CategoryIcon from '@material-ui/icons/Category';
 import HomeIcon from '@material-ui/icons/Home';
+import DashboardIcon from '@material-ui/icons/Dashboard';
 import CompareIcon from '@material-ui/icons/Compare';
 import CreditCardIcon from '@material-ui/icons/CreditCard';
 import InboxRounded from '@material-ui/icons/InboxRounded';
@@ -58,9 +60,31 @@ function getRoutes(user) {
     },
     {
       name: 'Verify',
-      linkTo: '/verify',
-      component: VerifyView,
-      icon: IconThumbsUpDown,
+      children: [
+        {
+          name: 'Dashboard',
+          linkTo: '/verify',
+          exact: true,
+          component: VerificationDashboardView,
+          icon: DashboardIcon,
+          disabled: !hasPermission(user, [
+            POLICIES.SUPER_PERMISSION,
+            POLICIES.LIST_TREE,
+            POLICIES.APPROVE_TREE,
+          ]),
+        },
+        {
+          name: 'Captures',
+          linkTo: '/verify/captures',
+          component: VerifyView,
+          icon: IconThumbsUpDown,
+          disabled: !hasPermission(user, [
+            POLICIES.SUPER_PERMISSION,
+            POLICIES.LIST_TREE,
+            POLICIES.APPROVE_TREE,
+          ]),
+        },
+      ],
       disabled: !hasPermission(user, [
         POLICIES.SUPER_PERMISSION,
         POLICIES.LIST_TREE,

--- a/src/views/VerificationDashboardView.js
+++ b/src/views/VerificationDashboardView.js
@@ -1,0 +1,13 @@
+import React, { useEffect } from 'react';
+import { documentTitle } from '../common/variables';
+import VerificationDashboard from '../components/VerificationDashboard/VerificationDashboard';
+
+function VerificationDashboardView() {
+  useEffect(() => {
+    document.title = `Verify Captures - ${documentTitle}`;
+  }, []);
+
+  return <VerificationDashboard />;
+}
+
+export default VerificationDashboardView;


### PR DESCRIPTION
## Description

**Issue(s) addressed**
Addresses Issue https://github.com/Greenstand/treetracker-admin-client/issues/1134

This is the "design" I'm envisioning. The "View all unverified captures" in this case will lead to the current verify page.

<img width="1275" height="781" alt="Screenshot 2026-09-06 at 2 07 33 PM" src="https://github.com/user-attachments/assets/37efd9e8-275d-4181-aff7-a976f5df9b9a" />

The actual change is pretty big so I've split it into 3 phases. Each phase is stand alone -- this way, we can actually merge and release every phase.

#### Phase 1 (THIS ONE)
- Set up a functional partial landing page
- No BE change, use the APIs we already have

#### Phase 2 
- Adding the tracking sessions panel and stats card in the new landing page
- Will require both BE + FE change

#### Phase 3
- Add tracking sessions as a filterable field for the captures
- Will require both BE + FE change 


**What kind of change(s) does this PR introduce?**

- [X] Enhancement
- [ ] Bug fix
- [X] Refactor

**Please check if the PR fulfils these requirements**

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?** Currently there is no landing page.

**What is the new behavior?** ^^^ Explained above

## Breaking change

**Does this PR introduce a breaking change?**
No

## Screenshots of the Change

<img width="1498" height="895" alt="Screenshot 2026-09-06 at 2 16 49 PM" src="https://github.com/user-attachments/assets/f2494520-9569-4104-93c1-4e784fca8dae" />

